### PR TITLE
Fix MCP Server timeouts.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ repositories {
 
 dependencies {
 	// MCP SDK core dependency
-	implementation 'io.modelcontextprotocol.sdk:mcp:0.10.0'
+	implementation 'io.modelcontextprotocol.sdk:mcp:0.14.1'
 	
 	// Jetty embedded server for servlet container
 	implementation 'org.eclipse.jetty:jetty-server:11.0.20'

--- a/src/main/java/ghidrassistmcp/GhidrAssistMCPBackend.java
+++ b/src/main/java/ghidrassistmcp/GhidrAssistMCPBackend.java
@@ -118,8 +118,12 @@ public class GhidrAssistMCPBackend implements McpBackend {
             if (toolEnabledStates.getOrDefault(tool.getName(), true)) {
                 toolList.add(new McpSchema.Tool(
                     tool.getName(),
+                    tool.getName(),
                     tool.getDescription(),
-                    tool.getInputSchema()
+                    tool.getInputSchema(),
+                    null,
+                    null,
+                    null
                 ));
             }
         }
@@ -352,8 +356,12 @@ public class GhidrAssistMCPBackend implements McpBackend {
         for (McpTool tool : tools.values()) {
             toolList.add(new McpSchema.Tool(
                 tool.getName(),
+                tool.getName(),
                 tool.getDescription(),
-                tool.getInputSchema()
+                tool.getInputSchema(),
+                null,
+                null,
+                null
             ));
         }
         // Sort tools alphabetically by name for consistent ordering


### PR DESCRIPTION
The lack of keep alive message support was recently fixed in the model context java library, without these keep alive messages tools like claude code will repeatedly disconnect from the server and require manual reconnection.