### PR TITLE
Narrow SSE servlet mapping to prevent HTTP 200 on invalid paths

### DIFF
--- a/src/main/java/ghidrassistmcp/GhidrAssistMCPServer.java
+++ b/src/main/java/ghidrassistmcp/GhidrAssistMCPServer.java
@@ -67,7 +67,7 @@ public class GhidrAssistMCPServer {
             // Create MCP transport provider using simple constructor
             Msg.info(this, "Creating MCP transport provider");
             McpJsonMapper mapper = McpJsonMapper.getDefault();
-            String messageEndpoint = "message";
+            String messageEndpoint = "/message";
             String mcpEndpoint = "/mcp";
 
             HttpServletSseServerTransportProvider sseTransportProvider =
@@ -118,7 +118,8 @@ public class GhidrAssistMCPServer {
             try {
                 ServletHolder mcpSseServletHolder = new ServletHolder("mcp-sse-transport", sseTransportProvider);
                 mcpSseServletHolder.setAsyncSupported(true);
-                context.addServlet(mcpSseServletHolder, "/*");
+                context.addServlet(mcpSseServletHolder, "/sse");
+                context.addServlet(mcpSseServletHolder, messageEndpoint);
 
                 ServletHolder mcpStreamableServletHolder = new ServletHolder("mcp-streamable-transport", streamableTransportProvider);
                 mcpStreamableServletHolder.setAsyncSupported(true);
@@ -132,7 +133,7 @@ public class GhidrAssistMCPServer {
                 Msg.info(this, "SSE endpoint will be: /sse (default)");
                 Msg.info(this, "Expected client URLs:");
                 Msg.info(this, "  SSE: http://" + host + ":" + port + "/sse");
-                Msg.info(this, "  Messages: http://" + host + ":" + port + "/" + messageEndpoint);
+                Msg.info(this, "  Messages: http://" + host + ":" + port + messageEndpoint);
                 Msg.info(this, "Streamable HTTP transport provider class: " + streamableTransportProvider.getClass().getName());
                 Msg.info(this, "Streamable MCP endpoint: http://" + host + ":" + port + mcpEndpoint);
                 
@@ -148,7 +149,7 @@ public class GhidrAssistMCPServer {
             if (jettyServer.isStarted()) {
                 Msg.info(this, "GhidrAssistMCP Server successfully started on port " + port);
                 Msg.info(this, "MCP SSE endpoint: http://" + host + ":" + port + "/sse");
-                Msg.info(this, "MCP message endpoint: http://" + host + ":" + port + "/" + messageEndpoint);
+                Msg.info(this, "MCP message endpoint: http://" + host + ":" + port + messageEndpoint);
                 Msg.info(this, "MCP Streamable endpoint: http://" + host + ":" + port + mcpEndpoint);
                 Msg.info(this, "Server state: " + jettyServer.getState());
                 


### PR DESCRIPTION
The `/*` servlet mapping was causing issues with LibreChat where, when LibreChat was configured to auto-detect the server authentication method, it would get stuck stuck trying to access `/.well-known/oauth-protected-resource/mcp` or `/.well-known/oauth-protected-resource/sse`. Because the server assumed all requests not going to `/mcp/*` or `/messages` were meant for the SSE servlet, the server would just hold the connection open forever. And because LibreChat failed to time-out (I assume because it kept receiving SSE pings from the server), it would not allow the MCP server to be added.

This change fixes that issue.