### PR TITLE
Make sure we use the correct port at startup by re-saving it

### DIFF
--- a/src/main/java/ghidrassistmcp/GhidrAssistMCPProvider.java
+++ b/src/main/java/ghidrassistmcp/GhidrAssistMCPProvider.java
@@ -385,6 +385,7 @@ public class GhidrAssistMCPProvider extends ComponentProvider implements McpEven
         // Load settings now that backend is ready
         loadSettings();
         refreshToolsList();
+        saveSettings();
         logMessage("Backend ready - settings loaded and tools list refreshed");
     }
     


### PR DESCRIPTION
Without this change, the server listens on port 8080 until the "Save Configuration" button is clicked, regardless of what the loaded value was.

There's probably a better way to do this, but I didn't understand the code well enough to implement it.