### PR TITLE
feat: Add isReadOnly flag to MCP tools

### DIFF
--- a/src/main/java/ghidrassistmcp/GhidrAssistMCPBackend.java
+++ b/src/main/java/ghidrassistmcp/GhidrAssistMCPBackend.java
@@ -137,11 +137,21 @@ public class GhidrAssistMCPBackend implements McpBackend {
                 // Augment the schema with program_name parameter for multi-program support
                 McpSchema.JsonSchema augmentedSchema = augmentSchemaWithProgramName(tool.getInputSchema());
 
+                McpSchema.ToolAnnotations annotations = new McpSchema.ToolAnnotations(
+                    null,
+                    tool.isReadOnly(),
+                    null,
+                    null,
+                    null,
+                    null
+                );
+
                 toolList.add(McpSchema.Tool.builder()
                     .name(tool.getName())
                     .title(tool.getName())
                     .description(tool.getDescription())
                     .inputSchema(augmentedSchema)
+                    .annotations(annotations)
                     .build());
             }
         }

--- a/src/main/java/ghidrassistmcp/McpTool.java
+++ b/src/main/java/ghidrassistmcp/McpTool.java
@@ -43,4 +43,8 @@ public interface McpTool {
         // Default implementation delegates to the original method for backward compatibility
         return execute(arguments, currentProgram);
     }
+
+    default boolean isReadOnly() {
+        return false;
+    }
 }

--- a/src/main/java/ghidrassistmcp/tools/DecompileFunctionTool.java
+++ b/src/main/java/ghidrassistmcp/tools/DecompileFunctionTool.java
@@ -104,29 +104,34 @@ public class DecompileFunctionTool implements McpTool {
         DecompInterface decompiler = new DecompInterface();
         try {
             decompiler.openProgram(function.getProgram());
-            
+
             DecompileResults results = decompiler.decompileFunction(function, 30, TaskMonitor.DUMMY);
-            
+
             if (results.isTimedOut()) {
                 return "Decompilation timed out for function: " + function.getName();
             }
-            
+
             if (results.isValid() == false) {
                 return "Decompilation error for function " + function.getName() + ": " + results.getErrorMessage();
             }
-            
+
             String decompiledCode = results.getDecompiledFunction().getC();
-            
+
             if (decompiledCode == null || decompiledCode.trim().isEmpty()) {
                 return "No decompiled code available for function: " + function.getName();
             }
-            
+
             return "Decompiled function " + function.getName() + ":\n\n" + decompiledCode;
-            
+
         } catch (Exception e) {
             return "Error decompiling function " + function.getName() + ": " + e.getMessage();
         } finally {
             decompiler.dispose();
         }
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        return true;
     }
 }

--- a/src/main/java/ghidrassistmcp/tools/DisassembleFunctionTool.java
+++ b/src/main/java/ghidrassistmcp/tools/DisassembleFunctionTool.java
@@ -127,12 +127,17 @@ public class DisassembleFunctionTool implements McpTool {
     private Function findFunctionByName(Program program, String functionName) {
         var functionManager = program.getFunctionManager();
         var functions = functionManager.getFunctions(true);
-        
+
         for (Function function : functions) {
             if (function.getName().equals(functionName)) {
                 return function;
             }
         }
         return null;
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        return true;
     }
 }

--- a/src/main/java/ghidrassistmcp/tools/FunctionXrefsTool.java
+++ b/src/main/java/ghidrassistmcp/tools/FunctionXrefsTool.java
@@ -167,4 +167,9 @@ public class FunctionXrefsTool implements McpTool {
         }
         return null;
     }
+
+    @Override
+    public boolean isReadOnly() {
+        return true;
+    }
 }

--- a/src/main/java/ghidrassistmcp/tools/GetClassInfoTool.java
+++ b/src/main/java/ghidrassistmcp/tools/GetClassInfoTool.java
@@ -1001,7 +1001,12 @@ public class GetClassInfoTool implements McpTool {
         } else {
             result.append("Total members found: ").append(totalMembers);
         }
-        
+
         return result.toString();
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        return true;
     }
 }

--- a/src/main/java/ghidrassistmcp/tools/GetCurrentAddressTool.java
+++ b/src/main/java/ghidrassistmcp/tools/GetCurrentAddressTool.java
@@ -80,4 +80,9 @@ public class GetCurrentAddressTool implements McpTool {
             .addTextContent(result.toString())
             .build();
     }
+
+    @Override
+    public boolean isReadOnly() {
+        return true;
+    }
 }

--- a/src/main/java/ghidrassistmcp/tools/GetCurrentFunctionTool.java
+++ b/src/main/java/ghidrassistmcp/tools/GetCurrentFunctionTool.java
@@ -96,4 +96,9 @@ public class GetCurrentFunctionTool implements McpTool {
             .addTextContent(result.toString())
             .build();
     }
+
+    @Override
+    public boolean isReadOnly() {
+        return true;
+    }
 }

--- a/src/main/java/ghidrassistmcp/tools/GetDataTypeTool.java
+++ b/src/main/java/ghidrassistmcp/tools/GetDataTypeTool.java
@@ -277,4 +277,9 @@ public class GetDataTypeTool implements McpTool {
         result.append("Type: Function Definition\n\n");
         result.append("Signature: ").append(funcDef.getPrototypeString()).append("\n");
     }
+
+    @Override
+    public boolean isReadOnly() {
+        return true;
+    }
 }

--- a/src/main/java/ghidrassistmcp/tools/GetFunctionByAddressTool.java
+++ b/src/main/java/ghidrassistmcp/tools/GetFunctionByAddressTool.java
@@ -89,4 +89,9 @@ public class GetFunctionByAddressTool implements McpTool {
             .addTextContent(result.toString())
             .build();
     }
+
+    @Override
+    public boolean isReadOnly() {
+        return true;
+    }
 }

--- a/src/main/java/ghidrassistmcp/tools/GetFunctionInfoTool.java
+++ b/src/main/java/ghidrassistmcp/tools/GetFunctionInfoTool.java
@@ -74,4 +74,9 @@ public class GetFunctionInfoTool implements McpTool {
         
         return "Function not found: " + functionName;
     }
+
+    @Override
+    public boolean isReadOnly() {
+        return true;
+    }
 }

--- a/src/main/java/ghidrassistmcp/tools/GetHexdumpTool.java
+++ b/src/main/java/ghidrassistmcp/tools/GetHexdumpTool.java
@@ -218,4 +218,9 @@ public class GetHexdumpTool implements McpTool {
 
         return line.toString();
     }
+
+    @Override
+    public boolean isReadOnly() {
+        return true;
+    }
 }

--- a/src/main/java/ghidrassistmcp/tools/ListClassesTool.java
+++ b/src/main/java/ghidrassistmcp/tools/ListClassesTool.java
@@ -266,4 +266,9 @@ public class ListClassesTool implements McpTool {
         
         return null;
     }
+
+    @Override
+    public boolean isReadOnly() {
+        return true;
+    }
 }

--- a/src/main/java/ghidrassistmcp/tools/ListDataTool.java
+++ b/src/main/java/ghidrassistmcp/tools/ListDataTool.java
@@ -136,4 +136,9 @@ public class ListDataTool implements McpTool {
             .addTextContent(result.toString())
             .build();
     }
+
+    @Override
+    public boolean isReadOnly() {
+        return true;
+    }
 }

--- a/src/main/java/ghidrassistmcp/tools/ListDataTypesTool.java
+++ b/src/main/java/ghidrassistmcp/tools/ListDataTypesTool.java
@@ -166,4 +166,9 @@ public class ListDataTypesTool implements McpTool {
             .addTextContent(result.toString())
             .build();
     }
+
+    @Override
+    public boolean isReadOnly() {
+        return true;
+    }
 }

--- a/src/main/java/ghidrassistmcp/tools/ListExportsTool.java
+++ b/src/main/java/ghidrassistmcp/tools/ListExportsTool.java
@@ -107,4 +107,9 @@ public class ListExportsTool implements McpTool {
             .addTextContent(result.toString())
             .build();
     }
+
+    @Override
+    public boolean isReadOnly() {
+        return true;
+    }
 }

--- a/src/main/java/ghidrassistmcp/tools/ListFunctionsTool.java
+++ b/src/main/java/ghidrassistmcp/tools/ListFunctionsTool.java
@@ -56,4 +56,9 @@ public class ListFunctionsTool implements McpTool {
         
         return functions.toString();
     }
+
+    @Override
+    public boolean isReadOnly() {
+        return true;
+    }
 }

--- a/src/main/java/ghidrassistmcp/tools/ListImportsTool.java
+++ b/src/main/java/ghidrassistmcp/tools/ListImportsTool.java
@@ -113,4 +113,9 @@ public class ListImportsTool implements McpTool {
             .addTextContent(result.toString())
             .build();
     }
+
+    @Override
+    public boolean isReadOnly() {
+        return true;
+    }
 }

--- a/src/main/java/ghidrassistmcp/tools/ListMethodsTool.java
+++ b/src/main/java/ghidrassistmcp/tools/ListMethodsTool.java
@@ -99,4 +99,9 @@ public class ListMethodsTool implements McpTool {
             .addTextContent(result.toString())
             .build();
     }
+
+    @Override
+    public boolean isReadOnly() {
+        return true;
+    }
 }

--- a/src/main/java/ghidrassistmcp/tools/ListNamespacesTool.java
+++ b/src/main/java/ghidrassistmcp/tools/ListNamespacesTool.java
@@ -125,4 +125,9 @@ public class ListNamespacesTool implements McpTool {
             .addTextContent(result.toString())
             .build();
     }
+
+    @Override
+    public boolean isReadOnly() {
+        return true;
+    }
 }

--- a/src/main/java/ghidrassistmcp/tools/ListProgramsTool.java
+++ b/src/main/java/ghidrassistmcp/tools/ListProgramsTool.java
@@ -101,4 +101,9 @@ public class ListProgramsTool implements McpTool {
             .addTextContent(result.toString())
             .build();
     }
+
+    @Override
+    public boolean isReadOnly() {
+        return true;
+    }
 }

--- a/src/main/java/ghidrassistmcp/tools/ListSegmentsTool.java
+++ b/src/main/java/ghidrassistmcp/tools/ListSegmentsTool.java
@@ -95,4 +95,9 @@ public class ListSegmentsTool implements McpTool {
             .addTextContent(result.toString())
             .build();
     }
+
+    @Override
+    public boolean isReadOnly() {
+        return true;
+    }
 }

--- a/src/main/java/ghidrassistmcp/tools/ListStringsTool.java
+++ b/src/main/java/ghidrassistmcp/tools/ListStringsTool.java
@@ -155,4 +155,9 @@ public class ListStringsTool implements McpTool {
 
         return defaultValueRepresentation;
     }
+
+    @Override
+    public boolean isReadOnly() {
+        return true;
+    }
 }

--- a/src/main/java/ghidrassistmcp/tools/ProgramInfoTool.java
+++ b/src/main/java/ghidrassistmcp/tools/ProgramInfoTool.java
@@ -57,4 +57,9 @@ public class ProgramInfoTool implements McpTool {
         
         return info.toString();
     }
+
+    @Override
+    public boolean isReadOnly() {
+        return true;
+    }
 }

--- a/src/main/java/ghidrassistmcp/tools/SearchClassesTool.java
+++ b/src/main/java/ghidrassistmcp/tools/SearchClassesTool.java
@@ -291,4 +291,9 @@ public class SearchClassesTool implements McpTool {
         
         return null;
     }
+
+    @Override
+    public boolean isReadOnly() {
+        return true;
+    }
 }

--- a/src/main/java/ghidrassistmcp/tools/SearchFunctionsTool.java
+++ b/src/main/java/ghidrassistmcp/tools/SearchFunctionsTool.java
@@ -120,4 +120,9 @@ public class SearchFunctionsTool implements McpTool {
             .addTextContent(result.toString())
             .build();
     }
+
+    @Override
+    public boolean isReadOnly() {
+        return true;
+    }
 }

--- a/src/main/java/ghidrassistmcp/tools/StructFieldXrefsTool.java
+++ b/src/main/java/ghidrassistmcp/tools/StructFieldXrefsTool.java
@@ -571,4 +571,9 @@ public class StructFieldXrefsTool implements McpTool {
 
         return null;
     }
+
+    @Override
+    public boolean isReadOnly() {
+        return true;
+    }
 }

--- a/src/main/java/ghidrassistmcp/tools/XrefsFromTool.java
+++ b/src/main/java/ghidrassistmcp/tools/XrefsFromTool.java
@@ -108,4 +108,9 @@ public class XrefsFromTool implements McpTool {
             .addTextContent(result.toString())
             .build();
     }
+
+    @Override
+    public boolean isReadOnly() {
+        return true;
+    }
 }

--- a/src/main/java/ghidrassistmcp/tools/XrefsToTool.java
+++ b/src/main/java/ghidrassistmcp/tools/XrefsToTool.java
@@ -120,4 +120,9 @@ public class XrefsToTool implements McpTool {
             .addTextContent(result.toString())
             .build();
     }
+
+    @Override
+    public boolean isReadOnly() {
+        return true;
+    }
 }


### PR DESCRIPTION
## Summary
- Add `isReadOnly` flag to MCP tools so AI clients can identify read-only tools
- Add `isReadOnly()` default method to `McpTool` interface (default: `false`)
- Expose read-only flag via `ToolAnnotations` in `GhidrAssistMCPBackend`
- Add `isReadOnly() { return true; }` override to 27 read-only tools

## Motivation
Some AI clients like ChatGPT Desktop require user approval for every tool call when the read-only flag is not set. This creates a poor user experience as users must manually approve each tool invocation. By properly marking read-only tools, AI clients can automatically execute them without prompting for approval, significantly improving the workflow.
