### PR TITLE
Incremental struct editing + “name gap” support

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,9 @@ These tools bundle related operations behind a discriminator parameter (e.g., `a
 | ------ | ----------- |
 | `create` | Create a new structure from C definition or empty |
 | `modify` | Modify an existing structure with new C definition |
+| `merge` | Merge (overlay) fields from a C definition onto an existing structure without deleting existing fields |
+| `set_field` | Set/insert a single field at a specific offset without needing a full C struct (use `field_name` to name it) |
+| `name_gap` | Convert undefined bytes at an offset/length into a named `byte[]`-like field (useful for “naming gaps”; uses `field_name`) |
 | `auto_create` | Automatically create structure from variable usage patterns |
 | `rename_field` | Rename a field within a structure |
 | `field_xrefs` | Find cross-references to a specific struct field |


### PR DESCRIPTION
## Problem

- `struct.modify` replaces whole struct from parsed C. Bad for incremental edits.
- Large C structs hard to paste/parse.
- “Gaps” show as undefined bytes; cannot rename because not real component.

## Change

- Extend tool `struct` with new actions:
  - `merge`: parse C struct, overlay fields onto existing struct, no `deleteAll()`. Refuse packed targets (unsafe). Optional `update_packing`.
  - `set_field`: set/insert one field at `field_offset` using Ghidra `replaceAtOffset` / `insertAtOffset`. Supports `pointer_level`, `array_count`, explicit `field_length`, optional `field_name` + `comment`, auto `grow`.
  - `name_gap`: turn undefined byte range into real named component by inserting `unsigned char[field_length]` at offset. Optional safety `allow_overwrite` (default false), auto `grow`.

## Why it helps

- Build huge structs step-by-step, no giant C block.
- Can label/preserve unknown bytes (“gaps”) as named arrays, so analysis + xrefs clearer.

## Notes / compat

- Schema uses `field_name` across set_field/name_gap/field_xrefs (single key).
- `merge` intended for non-packed structs; packed still use `modify` or `set_field`.