### PR TITLE
Add control for async tool execution

### DIFF
--- a/src/main/java/ghidrassistmcp/GhidrAssistMCPBackend.java
+++ b/src/main/java/ghidrassistmcp/GhidrAssistMCPBackend.java
@@ -75,6 +75,7 @@ public class GhidrAssistMCPBackend implements McpBackend {
     private final Map<String, Boolean> toolEnabledStates = new ConcurrentHashMap<>();
     private final List<McpEventListener> eventListeners = new CopyOnWriteArrayList<>();
     private volatile GhidrAssistMCPManager manager;
+    private volatile boolean asyncExecutionEnabled = true;
     private final McpTaskManager taskManager;
     private final McpResourceRegistry resourceRegistry;
     private final McpPromptRegistry promptRegistry;
@@ -270,7 +271,7 @@ public class GhidrAssistMCPBackend implements McpBackend {
             }
 
             // Check if this is a long-running tool that should be executed asynchronously
-            if (tool.isLongRunning()) {
+            if (tool.isLongRunning() && asyncExecutionEnabled) {
                 return executeToolAsync(tool, toolName, arguments, targetProgram);
             }
 
@@ -685,6 +686,21 @@ public class GhidrAssistMCPBackend implements McpBackend {
         }
 
         return result;
+    }
+
+    /**
+     * Set whether async execution is enabled for long-running tools.
+     */
+    public void setAsyncExecutionEnabled(boolean enabled) {
+        this.asyncExecutionEnabled = enabled;
+        Msg.info(this, "Async tool execution " + (enabled ? "enabled" : "disabled"));
+    }
+
+    /**
+     * Check whether async execution is enabled for long-running tools.
+     */
+    public boolean isAsyncExecutionEnabled() {
+        return asyncExecutionEnabled;
     }
 
     /**

--- a/src/main/java/ghidrassistmcp/GhidrAssistMCPManager.java
+++ b/src/main/java/ghidrassistmcp/GhidrAssistMCPManager.java
@@ -310,10 +310,10 @@ public class GhidrAssistMCPManager {
     /**
      * Apply configuration changes.
      */
-    public void applyConfiguration(String host, int port, boolean enabled,
+    public void applyConfiguration(String host, int port, boolean enabled, boolean asyncEnabled,
                                    java.util.Map<String, Boolean> toolStates) {
         if (provider != null) {
-            provider.logMessage("Applying configuration: " + host + ":" + port + " enabled=" + enabled);
+            provider.logMessage("Applying configuration: " + host + ":" + port + " enabled=" + enabled + " async=" + asyncEnabled);
         }
 
         boolean needsRestart = false;
@@ -327,6 +327,11 @@ public class GhidrAssistMCPManager {
         if (enabled != serverEnabled) {
             serverEnabled = enabled;
             needsRestart = true;
+        }
+
+        // Update async execution setting
+        if (backend != null) {
+            backend.setAsyncExecutionEnabled(asyncEnabled);
         }
 
         // Update tool states
@@ -370,6 +375,7 @@ public class GhidrAssistMCPManager {
         currentHost = Preferences.getProperty("GhidrAssistMCP.Server Host", "localhost");
         String portStr = Preferences.getProperty("GhidrAssistMCP.Server Port", "8080");
         String enabledStr = Preferences.getProperty("GhidrAssistMCP.Server Enabled", "true");
+        String asyncEnabledStr = Preferences.getProperty("GhidrAssistMCP.Async Execution Enabled", "true");
 
         try {
             currentPort = Integer.parseInt(portStr);
@@ -380,10 +386,15 @@ public class GhidrAssistMCPManager {
             serverEnabled = true;
         }
 
-        Msg.info(this, "Loaded settings from Ghidra preferences: " + currentHost + ":" + currentPort + " enabled=" + serverEnabled);
+        boolean asyncEnabled = Boolean.parseBoolean(asyncEnabledStr);
+        if (backend != null) {
+            backend.setAsyncExecutionEnabled(asyncEnabled);
+        }
+
+        Msg.info(this, "Loaded settings from Ghidra preferences: " + currentHost + ":" + currentPort + " enabled=" + serverEnabled + " async=" + asyncEnabled);
 
         if (provider != null) {
-            provider.logMessage("Loaded configuration: " + currentHost + ":" + currentPort + " enabled=" + serverEnabled);
+            provider.logMessage("Loaded configuration: " + currentHost + ":" + currentPort + " enabled=" + serverEnabled + " async=" + asyncEnabled);
         }
     }
 

--- a/src/main/java/ghidrassistmcp/GhidrAssistMCPPlugin.java
+++ b/src/main/java/ghidrassistmcp/GhidrAssistMCPPlugin.java
@@ -94,9 +94,9 @@ public class GhidrAssistMCPPlugin extends ProgramPlugin {
 	 * Apply new configuration from the UI.
 	 * Delegates to the singleton manager which handles server restart if needed.
 	 */
-	public void applyConfiguration(String host, int port, boolean enabled, Map<String, Boolean> toolStates) {
+	public void applyConfiguration(String host, int port, boolean enabled, boolean asyncEnabled, Map<String, Boolean> toolStates) {
 		if (manager != null) {
-			manager.applyConfiguration(host, port, enabled, toolStates);
+			manager.applyConfiguration(host, port, enabled, asyncEnabled, toolStates);
 		}
 	}
 	


### PR DESCRIPTION
### What

I added a checkbox to allow users to enable/disable the use of async tool execution.

### Why

I found some LLM models better than others with the async tool execution. Some were getting confused about validation errors being reported in the get_task_status and not knowing if they applied to the tool that triggered the async execution or get_task_status itself. There were also times when juggling the various tasks and getting the result of all of them slowed things down.

I figured making it optional (with it defaulting to using async executions) would give the best flexibility as LLM models continue to change.

### Screenshot
<img width="516" height="278" alt="image" src="https://github.com/user-attachments/assets/3cee5cf3-d0cf-44bb-bb5e-bae9cd406280" />
