### PR TITLE
Add create_function and disassemble_at tools

### DIFF
--- a/src/main/java/ghidrassistmcp/GhidrAssistMCPBackend.java
+++ b/src/main/java/ghidrassistmcp/GhidrAssistMCPBackend.java
@@ -34,6 +34,8 @@ import ghidrassistmcp.tools.CancelTaskTool;
 import ghidrassistmcp.tools.ClassTool;
 import ghidrassistmcp.tools.CommentsTool;
 import ghidrassistmcp.tools.CreateDataVarTool;
+import ghidrassistmcp.tools.CreateFunctionTool;
+import ghidrassistmcp.tools.DisassembleAtTool;
 import ghidrassistmcp.tools.GetBasicBlocksTool;
 import ghidrassistmcp.tools.GetCodeTool;
 import ghidrassistmcp.tools.GetCurrentAddressTool;
@@ -137,6 +139,8 @@ public class GhidrAssistMCPBackend implements McpBackend {
         registerTool(new GetFunctionStackLayoutTool());
         registerTool(new SearchStringsTool());
         registerTool(new CreateDataVarTool());
+        registerTool(new CreateFunctionTool());       // create_function
+        registerTool(new DisassembleAtTool());         // disassemble_at
         registerTool(new GetEntryPointsTool());
 
         // Register async task management tools

--- a/src/main/java/ghidrassistmcp/tools/CreateFunctionTool.java
+++ b/src/main/java/ghidrassistmcp/tools/CreateFunctionTool.java
@@ -1,0 +1,144 @@
+/*
+ * MCP tool to create (define) a function at a given address in the current program.
+ * Optionally accepts a name for the new function.
+ */
+package ghidrassistmcp.tools;
+
+import java.util.List;
+import java.util.Map;
+
+import ghidra.app.cmd.function.CreateFunctionCmd;
+import ghidra.program.model.address.Address;
+import ghidra.program.model.listing.Function;
+import ghidra.program.model.listing.Program;
+import ghidra.program.model.symbol.SourceType;
+import ghidrassistmcp.McpTool;
+import io.modelcontextprotocol.spec.McpSchema;
+public class CreateFunctionTool implements McpTool {
+
+    @Override
+    public boolean isReadOnly() { return false; }
+
+    @Override
+    public boolean isIdempotent() { return true; }
+
+    @Override
+    public String getName() { return "create_function"; }
+
+    @Override
+    public String getDescription() {
+        return "Create (define) a function at a specific address. "
+             + "Ghidra will auto-detect the function body via flow analysis. "
+             + "Optionally provide a name for the function.";
+    }
+
+    @Override
+    public McpSchema.JsonSchema getInputSchema() {
+        return new McpSchema.JsonSchema("object",
+            Map.of(
+                "address", Map.of("type", "string",
+                    "description", "Entry point address for the function (e.g. '0xC121' or 'C121')"),
+                "name", Map.of("type", "string",
+                    "description", "Optional name for the function (default: auto-generated FUN_xxxx)")
+            ),
+            List.of("address"), null, null, null);
+    }
+
+    @Override
+    public McpSchema.CallToolResult execute(Map<String, Object> arguments, Program currentProgram) {
+        if (currentProgram == null) {
+            return McpSchema.CallToolResult.builder()
+                .addTextContent("No program currently loaded").build();
+        }
+
+        String addressStr = (String) arguments.get("address");
+        String name = (String) arguments.get("name");
+
+        Address entryPoint;
+        try {
+            entryPoint = currentProgram.getAddressFactory().getAddress(addressStr);
+        } catch (Exception e) {
+            return McpSchema.CallToolResult.builder()
+                .addTextContent("Invalid address: " + addressStr).build();
+        }
+
+        if (entryPoint == null) {
+            return McpSchema.CallToolResult.builder()
+                .addTextContent("Could not parse address: " + addressStr).build();
+        }
+
+        // Check if a function already exists at this address
+        Function existing = currentProgram.getFunctionManager().getFunctionAt(entryPoint);
+        if (existing != null) {
+            return McpSchema.CallToolResult.builder()
+                .addTextContent("Function already exists at " + addressStr + ": "
+                    + existing.getName() + " (" + existing.getBody().getNumAddresses() + " bytes)")
+                .build();
+        }
+
+        // Use CreateFunctionCmd which performs flow-based body detection
+        CreateFunctionCmd cmd = new CreateFunctionCmd(entryPoint);
+        boolean success = cmd.applyTo(currentProgram);
+
+        if (!success) {
+            // Fallback: try to disassemble first, then create function
+            int txId = currentProgram.startTransaction("Disassemble for function creation");
+            try {
+                ghidra.app.cmd.disassemble.DisassembleCommand disCmd =
+                    new ghidra.app.cmd.disassemble.DisassembleCommand(entryPoint, null, true);
+                disCmd.applyTo(currentProgram);
+                currentProgram.endTransaction(txId, true);
+
+                // Retry function creation after disassembly
+                cmd = new CreateFunctionCmd(entryPoint);
+                success = cmd.applyTo(currentProgram);
+            } catch (Exception e) {
+                currentProgram.endTransaction(txId, false);
+                return McpSchema.CallToolResult.builder()
+                    .addTextContent("Failed to disassemble at " + addressStr + ": " + e.getMessage())
+                    .build();
+            }
+        }
+
+        if (!success) {
+            return McpSchema.CallToolResult.builder()
+                .addTextContent("Failed to create function at " + addressStr
+                    + ". The address may not contain valid code or may overlap an existing function.")
+                .build();
+        }
+
+        // Get the created function
+        Function func = currentProgram.getFunctionManager().getFunctionAt(entryPoint);
+        if (func == null) {
+            return McpSchema.CallToolResult.builder()
+                .addTextContent("Function creation reported success but function not found at " + addressStr)
+                .build();
+        }
+
+        // Rename if a name was provided
+        if (name != null && !name.isEmpty()) {
+            int txId = currentProgram.startTransaction("Rename function");
+            try {
+                func.setName(name, SourceType.USER_DEFINED);
+                currentProgram.endTransaction(txId, true);
+            } catch (Exception e) {
+                currentProgram.endTransaction(txId, false);
+                return McpSchema.CallToolResult.builder()
+                    .addTextContent("Function created at " + addressStr
+                        + " but rename failed: " + e.getMessage())
+                    .build();
+            }
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("Function created successfully:\n");
+        sb.append("  Name: ").append(func.getName()).append("\n");
+        sb.append("  Entry: ").append(func.getEntryPoint()).append("\n");
+        sb.append("  Body size: ").append(func.getBody().getNumAddresses()).append(" bytes\n");
+        sb.append("  Range: ").append(func.getBody().getMinAddress())
+          .append(" - ").append(func.getBody().getMaxAddress());
+
+        return McpSchema.CallToolResult.builder()
+            .addTextContent(sb.toString()).build();
+    }
+}

--- a/src/main/java/ghidrassistmcp/tools/DisassembleAtTool.java
+++ b/src/main/java/ghidrassistmcp/tools/DisassembleAtTool.java
@@ -1,0 +1,121 @@
+/*
+ * MCP tool to disassemble bytes at a given address, even if no function is defined there.
+ * Useful for inspecting code regions that haven't been auto-analyzed.
+ */
+package ghidrassistmcp.tools;
+
+import java.util.List;
+import java.util.Map;
+
+import ghidra.app.cmd.disassemble.DisassembleCommand;
+import ghidra.program.model.address.Address;
+import ghidra.program.model.address.AddressSet;
+import ghidra.program.model.listing.Instruction;
+import ghidra.program.model.listing.InstructionIterator;
+import ghidra.program.model.listing.Listing;
+import ghidra.program.model.listing.Program;
+import ghidrassistmcp.McpTool;
+import io.modelcontextprotocol.spec.McpSchema;
+public class DisassembleAtTool implements McpTool {
+
+    @Override
+    public boolean isReadOnly() { return false; }
+
+    @Override
+    public boolean isIdempotent() { return true; }
+
+    @Override
+    public String getName() { return "disassemble_at"; }
+
+    @Override
+    public String getDescription() {
+        return "Disassemble code at a specific address, even if no function is defined. "
+             + "Converts undefined bytes into instructions and returns the disassembly listing.";
+    }
+
+    @Override
+    public McpSchema.JsonSchema getInputSchema() {
+        return new McpSchema.JsonSchema("object",
+            Map.of(
+                "address", Map.of("type", "string",
+                    "description", "Start address to disassemble (e.g. '0xC121' or 'C121')"),
+                "length", Map.of("type", "integer",
+                    "description", "Maximum number of bytes to disassemble (default: 128)")
+            ),
+            List.of("address"), null, null, null);
+    }
+
+    @Override
+    public McpSchema.CallToolResult execute(Map<String, Object> arguments, Program currentProgram) {
+        if (currentProgram == null) {
+            return McpSchema.CallToolResult.builder()
+                .addTextContent("No program currently loaded").build();
+        }
+
+        String addressStr = (String) arguments.get("address");
+        int length = 128;
+        Object lengthObj = arguments.get("length");
+        if (lengthObj instanceof Number) {
+            length = ((Number) lengthObj).intValue();
+        }
+
+        // Cap at a reasonable maximum
+        if (length > 4096) length = 4096;
+        if (length < 1) length = 128;
+
+        Address startAddr;
+        try {
+            startAddr = currentProgram.getAddressFactory().getAddress(addressStr);
+        } catch (Exception e) {
+            return McpSchema.CallToolResult.builder()
+                .addTextContent("Invalid address: " + addressStr).build();
+        }
+
+        if (startAddr == null) {
+            return McpSchema.CallToolResult.builder()
+                .addTextContent("Could not parse address: " + addressStr).build();
+        }
+
+        Address endAddr = startAddr.add(length - 1);
+        AddressSet range = new AddressSet(startAddr, endAddr);
+
+        // Disassemble the region (this is a write operation - converts bytes to instructions)
+        int txId = currentProgram.startTransaction("Disassemble at " + addressStr);
+        try {
+            DisassembleCommand cmd = new DisassembleCommand(startAddr, range, true);
+            cmd.applyTo(currentProgram);
+            currentProgram.endTransaction(txId, true);
+        } catch (Exception e) {
+            currentProgram.endTransaction(txId, false);
+            return McpSchema.CallToolResult.builder()
+                .addTextContent("Disassembly failed at " + addressStr + ": " + e.getMessage())
+                .build();
+        }
+
+        // Now read back the disassembled instructions
+        Listing listing = currentProgram.getListing();
+        StringBuilder sb = new StringBuilder();
+        sb.append("Disassembly at ").append(startAddr).append(":\n\n");
+
+        int instrCount = 0;
+        InstructionIterator iter = listing.getInstructions(startAddr, true);
+        while (iter.hasNext()) {
+            Instruction instr = iter.next();
+            if (instr.getAddress().compareTo(endAddr) > 0) break;
+
+            sb.append(String.format("%s: %s\n", instr.getAddress(), instr.toString()));
+            instrCount++;
+
+            // Safety limit
+            if (instrCount > 500) {
+                sb.append("... (truncated at 500 instructions)\n");
+                break;
+            }
+        }
+
+        sb.append("\nTotal instructions: ").append(instrCount);
+
+        return McpSchema.CallToolResult.builder()
+            .addTextContent(sb.toString()).build();
+    }
+}


### PR DESCRIPTION
## Summary

- **`create_function`** — Define a function at a specific address via MCP. Uses Ghidra's `CreateFunctionCmd` for flow-based body detection. Falls back to disassembling undefined bytes first if the initial attempt fails. Optionally accepts a name for the new function. Returns entry point, body size, and address range on success. Idempotent — reports existing function info if one already exists at the address.
- **`disassemble_at`** — Disassemble code at a specific address, even if no function is defined there. Converts undefined bytes into instructions using Ghidra's `DisassembleCommand` and returns the disassembly listing. Accepts a configurable length parameter (default 128 bytes, max 4096). Useful for inspecting code regions that haven't been auto-analyzed.

## Motivation

MCP clients working with raw binary imports (e.g. NES ROM banks) frequently encounter addresses that Ghidra hasn't auto-analyzed into functions. Currently, the only way to define functions or disassemble unknown regions is through the Ghidra UI. These two tools close that gap:

1. `create_function` lets the client promote a known entry point into a proper Ghidra function with full flow analysis
2. `disassemble_at` lets the client inspect raw bytes as instructions without requiring a function definition — essential for examining code at addresses discovered through cross-references or runtime analysis

## Build notes

Uses `CreateFunctionCmd` and `DisassembleCommand` from `ghidra.app.cmd` — stable Ghidra APIs. Compiles cleanly against Ghidra 12.0.3 with zero errors and zero new warnings.

## Test plan

- [x] Build with `gradle buildExtension` against Ghidra 12.0.3 — compiles cleanly
- [x] `create_function` at an undefined address — creates function with correct body detection
- [x] `create_function` at an address with undefined bytes — auto-disassembles then creates function
- [x] `create_function` at an address with an existing function — returns existing function info (idempotent)
- [x] `create_function` with optional `name` parameter — function is renamed
- [x] `disassemble_at` on undefined bytes — converts to instructions and returns listing
- [x] `disassemble_at` with custom `length` — respects the length parameter
- [x] Both tools appear in the GhidrAssistMCP configuration panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)