### PR TITLE
Add MCP support for byte patching

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ GhidrAssistMCP bridges the gap between AI-powered analysis tools and Ghidra's co
 
 - **MCP Server Integration**: Full Model Context Protocol server implementation using official SDK
 - **Dual HTTP Transports**: Supports SSE and Streamable HTTP transports for maximum client compatibility
-- **35 Built-in Tools**: Comprehensive set of analysis tools with action-based consolidation for cleaner APIs
+- **37 Built-in Tools**: Comprehensive set of analysis tools with action-based consolidation for cleaner APIs
 - **6 MCP Resources**: Static data resources for program info, functions, strings, imports, exports, and segments
 - **7 MCP Prompts**: Pre-built analysis prompts for common reverse engineering tasks
 - **Result Caching**: Intelligent caching system to improve performance for repeated queries
@@ -98,14 +98,14 @@ Shameless self-promotion: [GhidrAssist](https://github.com/jtang613/GhidrAssist)
 
 The Configuration tab allows you to:
 
-- **View all available tools** (35 total)
+- **View all available tools** (37 total)
 - **Enable/disable individual tools** using checkboxes
 - **Save configuration** to persist across sessions
 - **Monitor tool status** in real-time
 
 ## Available Tools
 
-GhidrAssistMCP provides 35 tools organized into categories. Several tools use an action-based API pattern where a single tool provides multiple related operations.
+GhidrAssistMCP provides 37 tools organized into categories. Several tools use an action-based API pattern where a single tool provides multiple related operations.
 
 ### Binary & Program Management
 
@@ -113,6 +113,8 @@ GhidrAssistMCP provides 35 tools organized into categories. Several tools use an
 | ---- | ----------- |
 | `get_binary_info` | Get basic program information (name, architecture, compiler, etc.) |
 | `list_binaries` | List all open programs across all CodeBrowser windows |
+| `patch_bytes` | Patch raw bytes in program memory at a given address |
+| `export_program` | Export the current program to disk (`binary` or `original_file`) |
 
 ### Function Discovery & Analysis
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,9 @@ GhidrAssistMCP provides 37 tools organized into categories. Several tools use an
 | `get_binary_info` | Get basic program information (name, architecture, compiler, etc.) |
 | `list_binaries` | List all open programs across all CodeBrowser windows |
 | `patch_bytes` | Patch raw bytes in program memory at a given address |
-| `export_program` | Export the current program to disk (`binary` or `original_file`) |
+| `export_program` | Export the current program to disk (`binary` or `original_file`) *(disabled by default)* |
+
+> **Security-sensitive tools:** `import_file` and `export_program` are disabled by default because they interact with the host filesystem. Enable them explicitly in the plugin configuration UI when needed.
 
 ### Function Discovery & Analysis
 

--- a/src/main/java/ghidrassistmcp/GhidrAssistMCPBackend.java
+++ b/src/main/java/ghidrassistmcp/GhidrAssistMCPBackend.java
@@ -39,6 +39,7 @@ import ghidrassistmcp.tools.DisassembleAtTool;
 import ghidrassistmcp.tools.GetBasicBlocksTool;
 import ghidrassistmcp.tools.ImportFileTool;
 import ghidrassistmcp.tools.OpenProgramTool;
+import ghidrassistmcp.tools.ExportProgramTool;
 import ghidrassistmcp.tools.GetCodeTool;
 import ghidrassistmcp.tools.GetCurrentAddressTool;
 import ghidrassistmcp.tools.GetCurrentFunctionTool;
@@ -62,6 +63,7 @@ import ghidrassistmcp.tools.ListTasksTool;
 import ghidrassistmcp.tools.ProgramInfoTool;
 import ghidrassistmcp.tools.RenameSymbolBatchTool;
 import ghidrassistmcp.tools.RenameSymbolTool;
+import ghidrassistmcp.tools.PatchBytesTool;
 import ghidrassistmcp.tools.SearchBytesTool;
 import ghidrassistmcp.tools.SearchFunctionsByNameTool;
 import ghidrassistmcp.tools.SearchStringsTool;
@@ -147,10 +149,13 @@ public class GhidrAssistMCPBackend implements McpBackend {
 
         // Register project-level tools
         registerTool(new OpenProgramTool());          // open_program: open/list project files in CodeBrowser
+        registerTool(new PatchBytesTool());           // patch_bytes: write patched bytes into program memory
 
         // Register tools that are disabled by default (security-sensitive)
         registerTool(new ImportFileTool());
         toolEnabledStates.put("import_file", false); // disabled by default: exposes host file-system read access
+        registerTool(new ExportProgramTool());
+        toolEnabledStates.put("export_program", false); // disabled by default: writes files to host filesystem
 
         // Register async task management tools
         registerTool(new GetTaskStatusTool());

--- a/src/main/java/ghidrassistmcp/tools/ExportProgramTool.java
+++ b/src/main/java/ghidrassistmcp/tools/ExportProgramTool.java
@@ -1,0 +1,130 @@
+/*
+ * MCP tool to export the current program/binary to disk.
+ */
+package ghidrassistmcp.tools;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import ghidra.app.util.exporter.BinaryExporter;
+import ghidra.app.util.exporter.Exporter;
+import ghidra.app.util.exporter.ExporterException;
+import ghidra.app.util.exporter.OriginalFileExporter;
+import ghidra.program.model.listing.Program;
+import ghidra.util.task.TaskMonitor;
+import ghidrassistmcp.McpTool;
+import io.modelcontextprotocol.spec.McpSchema;
+
+/**
+ * Exports the active program to a host file.
+ */
+public class ExportProgramTool implements McpTool {
+
+    @Override
+    public String getName() {
+        return "export_program";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Export the program to disk. Supports format 'binary' (raw bytes) or 'original_file'. " +
+               "Use after patching bytes to write a modified binary.";
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        return false;
+    }
+
+    @Override
+    public boolean isIdempotent() {
+        return false;
+    }
+
+    @Override
+    public boolean isOpenWorld() {
+        return true;
+    }
+
+    @Override
+    public McpSchema.JsonSchema getInputSchema() {
+        return new McpSchema.JsonSchema("object",
+            Map.of(
+                "output_path", Map.of(
+                    "type", "string",
+                    "description", "Absolute output path on the host filesystem"),
+                "format", Map.of(
+                    "type", "string",
+                    "description", "Export format",
+                    "enum", List.of("binary", "original_file")),
+                "overwrite", Map.of(
+                    "type", "boolean",
+                    "description", "Overwrite existing file. Default: false")
+            ),
+            List.of("output_path"), null, null, null);
+    }
+
+    @Override
+    public McpSchema.CallToolResult execute(Map<String, Object> arguments, Program currentProgram) {
+        if (currentProgram == null) {
+            return textResult("No program currently loaded");
+        }
+
+        String outputPath = (String) arguments.get("output_path");
+        if (outputPath == null || outputPath.isBlank()) {
+            return textResult("output_path is required");
+        }
+
+        String format = (String) arguments.get("format");
+        if (format == null || format.isBlank()) {
+            format = "binary";
+        }
+
+        boolean overwrite = Boolean.TRUE.equals(arguments.get("overwrite"));
+
+        File outputFile = new File(outputPath);
+        if (outputFile.exists() && !overwrite) {
+            return textResult("Output file already exists: " + outputPath + " (set overwrite=true to replace it)");
+        }
+
+        File parent = outputFile.getAbsoluteFile().getParentFile();
+        if (parent != null && !parent.exists() && !parent.mkdirs()) {
+            return textResult("Failed to create output directory: " + parent.getAbsolutePath());
+        }
+
+        Exporter exporter;
+        switch (format.toLowerCase()) {
+            case "binary":
+                exporter = new BinaryExporter();
+                break;
+            case "original_file":
+                exporter = new OriginalFileExporter();
+                break;
+            default:
+                return textResult("Unsupported format: " + format + ". Use 'binary' or 'original_file'.");
+        }
+
+        try {
+            boolean success = exporter.export(outputFile, currentProgram, null, TaskMonitor.DUMMY);
+            if (!success) {
+                return textResult("Export failed (exporter returned false). Check Ghidra logs for details.");
+            }
+
+            return textResult("Export successful\n" +
+                "Program: " + currentProgram.getName() + "\n" +
+                "Format: " + format + "\n" +
+                "Output: " + outputFile.getAbsolutePath() + "\n" +
+                "Bytes written: " + outputFile.length());
+        } catch (ExporterException | IOException e) {
+            return textResult("Export failed: " + e.getClass().getSimpleName() + ": " + e.getMessage());
+        }
+    }
+
+    private static McpSchema.CallToolResult textResult(String message) {
+        return McpSchema.CallToolResult.builder()
+            .addTextContent(message)
+            .build();
+    }
+}

--- a/src/main/java/ghidrassistmcp/tools/ExportProgramTool.java
+++ b/src/main/java/ghidrassistmcp/tools/ExportProgramTool.java
@@ -30,7 +30,8 @@ public class ExportProgramTool implements McpTool {
     @Override
     public String getDescription() {
         return "Export the program to disk. Supports format 'binary' (raw bytes) or 'original_file'. " +
-               "Use after patching bytes to write a modified binary.";
+               "Use after patching bytes to write a modified binary. " +
+               "SECURITY: This tool writes to the host filesystem and is disabled by default.";
     }
 
     @Override
@@ -81,6 +82,7 @@ public class ExportProgramTool implements McpTool {
         if (format == null || format.isBlank()) {
             format = "binary";
         }
+        format = format.toLowerCase();
 
         boolean overwrite = Boolean.TRUE.equals(arguments.get("overwrite"));
 
@@ -95,7 +97,7 @@ public class ExportProgramTool implements McpTool {
         }
 
         Exporter exporter;
-        switch (format.toLowerCase()) {
+        switch (format) {
             case "binary":
                 exporter = new BinaryExporter();
                 break;

--- a/src/main/java/ghidrassistmcp/tools/PatchBytesTool.java
+++ b/src/main/java/ghidrassistmcp/tools/PatchBytesTool.java
@@ -51,8 +51,7 @@ public class PatchBytesTool implements McpTool {
                     "type", "string",
                     "description", "Address to patch (e.g. '0x401000' or '401000')"),
                 "bytes", Map.of(
-                    "type", "string",
-                    "description", "Hex bytes to write. Separators allowed: spaces/commas. Example: '90 90'"),
+                    "description", "Bytes to write. Either a hex string (e.g. '90 90') or an integer array (e.g. [144, 144])."),
                 "clear_code_units", Map.of(
                     "type", "boolean",
                     "description", "If true, clear existing instructions/data at the patched range before writing. Default: false")
@@ -67,30 +66,24 @@ public class PatchBytesTool implements McpTool {
         }
 
         String addressStr = (String) arguments.get("address");
-        String bytesStr = (String) arguments.get("bytes");
+        Object bytesObj = arguments.get("bytes");
         boolean clearCodeUnits = Boolean.TRUE.equals(arguments.get("clear_code_units"));
 
         if (addressStr == null || addressStr.isBlank()) {
             return textResult("address is required");
         }
-        if (bytesStr == null || bytesStr.isBlank()) {
+        if (bytesObj == null) {
             return textResult("bytes is required");
         }
 
-        Address address;
-        try {
-            address = currentProgram.getAddressFactory().getAddress(addressStr);
-        } catch (Exception e) {
-            return textResult("Invalid address: " + addressStr);
-        }
-
+        Address address = parseAddress(currentProgram, addressStr);
         if (address == null) {
             return textResult("Could not parse address: " + addressStr);
         }
 
         byte[] patchBytes;
         try {
-            patchBytes = parseHexBytes(bytesStr);
+            patchBytes = parsePatchBytes(bytesObj);
         } catch (IllegalArgumentException e) {
             return textResult("Invalid bytes format: " + e.getMessage());
         }
@@ -141,6 +134,53 @@ public class PatchBytesTool implements McpTool {
         }
 
         return textResult(sb.toString());
+    }
+
+    private static Address parseAddress(Program program, String addressStr) {
+        try {
+            Address parsed = program.getAddressFactory().getAddress(addressStr);
+            if (parsed != null) {
+                return parsed;
+            }
+        } catch (Exception ignored) {
+            // Fall through to numeric parse
+        }
+
+        try {
+            String clean = addressStr.strip();
+            if (clean.startsWith("0x") || clean.startsWith("0X")) {
+                clean = clean.substring(2);
+            }
+            long value = Long.parseUnsignedLong(clean, 16);
+            return program.getAddressFactory().getDefaultAddressSpace().getAddress(value);
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
+    private static byte[] parsePatchBytes(Object input) {
+        if (input instanceof String) {
+            return parseHexBytes((String) input);
+        }
+
+        if (input instanceof List<?>) {
+            List<?> list = (List<?>) input;
+            byte[] out = new byte[list.size()];
+            for (int i = 0; i < list.size(); i++) {
+                Object item = list.get(i);
+                if (!(item instanceof Number)) {
+                    throw new IllegalArgumentException("array element at index " + i + " is not a number");
+                }
+                int value = ((Number) item).intValue();
+                if (value < 0 || value > 255) {
+                    throw new IllegalArgumentException("array element at index " + i + " out of range (0-255): " + value);
+                }
+                out[i] = (byte) value;
+            }
+            return out;
+        }
+
+        throw new IllegalArgumentException("bytes must be a hex string or integer array");
     }
 
     private static byte[] parseHexBytes(String input) {

--- a/src/main/java/ghidrassistmcp/tools/PatchBytesTool.java
+++ b/src/main/java/ghidrassistmcp/tools/PatchBytesTool.java
@@ -1,0 +1,187 @@
+/*
+ * MCP tool to patch bytes at a specific address.
+ */
+package ghidrassistmcp.tools;
+
+import java.util.List;
+import java.util.Map;
+
+import ghidra.program.model.address.Address;
+import ghidra.program.model.listing.Program;
+import ghidra.program.model.mem.Memory;
+import ghidra.program.model.mem.MemoryAccessException;
+import ghidrassistmcp.McpTool;
+import io.modelcontextprotocol.spec.McpSchema;
+
+/**
+ * Applies raw byte patches to the loaded program.
+ */
+public class PatchBytesTool implements McpTool {
+
+    @Override
+    public String getName() {
+        return "patch_bytes";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Patch raw bytes at an address. Example: {\"address\":\"0x401000\",\"bytes\":\"90 90\"}";
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        return false;
+    }
+
+    @Override
+    public boolean isDestructive() {
+        return true;
+    }
+
+    @Override
+    public boolean isIdempotent() {
+        return true;
+    }
+
+    @Override
+    public McpSchema.JsonSchema getInputSchema() {
+        return new McpSchema.JsonSchema("object",
+            Map.of(
+                "address", Map.of(
+                    "type", "string",
+                    "description", "Address to patch (e.g. '0x401000' or '401000')"),
+                "bytes", Map.of(
+                    "type", "string",
+                    "description", "Hex bytes to write. Separators allowed: spaces/commas. Example: '90 90'"),
+                "clear_code_units", Map.of(
+                    "type", "boolean",
+                    "description", "If true, clear existing instructions/data at the patched range before writing. Default: false")
+            ),
+            List.of("address", "bytes"), null, null, null);
+    }
+
+    @Override
+    public McpSchema.CallToolResult execute(Map<String, Object> arguments, Program currentProgram) {
+        if (currentProgram == null) {
+            return textResult("No program currently loaded");
+        }
+
+        String addressStr = (String) arguments.get("address");
+        String bytesStr = (String) arguments.get("bytes");
+        boolean clearCodeUnits = Boolean.TRUE.equals(arguments.get("clear_code_units"));
+
+        if (addressStr == null || addressStr.isBlank()) {
+            return textResult("address is required");
+        }
+        if (bytesStr == null || bytesStr.isBlank()) {
+            return textResult("bytes is required");
+        }
+
+        Address address;
+        try {
+            address = currentProgram.getAddressFactory().getAddress(addressStr);
+        } catch (Exception e) {
+            return textResult("Invalid address: " + addressStr);
+        }
+
+        if (address == null) {
+            return textResult("Could not parse address: " + addressStr);
+        }
+
+        byte[] patchBytes;
+        try {
+            patchBytes = parseHexBytes(bytesStr);
+        } catch (IllegalArgumentException e) {
+            return textResult("Invalid bytes format: " + e.getMessage());
+        }
+
+        if (patchBytes.length == 0) {
+            return textResult("No bytes provided to patch");
+        }
+
+        Memory memory = currentProgram.getMemory();
+        Address endAddress;
+        try {
+            endAddress = address.addNoWrap(patchBytes.length - 1);
+        } catch (Exception e) {
+            return textResult("Patch range overflows address space: " + e.getMessage());
+        }
+
+        if (!memory.contains(address) || !memory.contains(endAddress)) {
+            return textResult("Patch range is outside mapped memory: " + address + " - " + endAddress);
+        }
+
+        byte[] oldBytes = new byte[patchBytes.length];
+        try {
+            memory.getBytes(address, oldBytes);
+        } catch (MemoryAccessException e) {
+            return textResult("Failed reading original bytes: " + e.getMessage());
+        }
+
+        int txId = currentProgram.startTransaction("MCP Patch Bytes at " + address);
+        try {
+            if (clearCodeUnits) {
+                currentProgram.getListing().clearCodeUnits(address, endAddress, false);
+            }
+
+            memory.setBytes(address, patchBytes);
+            currentProgram.endTransaction(txId, true);
+        } catch (Exception e) {
+            currentProgram.endTransaction(txId, false);
+            return textResult("Patch failed: " + e.getMessage());
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("Patched ").append(patchBytes.length).append(" byte(s) at ").append(address).append("\n");
+        sb.append("Range: ").append(address).append(" - ").append(endAddress).append("\n");
+        sb.append("Before: ").append(toHex(oldBytes)).append("\n");
+        sb.append("After:  ").append(toHex(patchBytes));
+        if (clearCodeUnits) {
+            sb.append("\nCode units cleared in patched range: yes");
+        }
+
+        return textResult(sb.toString());
+    }
+
+    private static byte[] parseHexBytes(String input) {
+        String normalized = input.replaceAll("0x", "")
+            .replaceAll("0X", "")
+            .replaceAll("[,\\s]", "");
+
+        if (normalized.isEmpty()) {
+            return new byte[0];
+        }
+        if ((normalized.length() & 1) != 0) {
+            throw new IllegalArgumentException("hex string must contain an even number of characters");
+        }
+
+        int len = normalized.length() / 2;
+        byte[] bytes = new byte[len];
+        for (int i = 0; i < len; i++) {
+            String hex = normalized.substring(i * 2, i * 2 + 2);
+            try {
+                bytes[i] = (byte) Integer.parseInt(hex, 16);
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException("invalid hex byte '" + hex + "'");
+            }
+        }
+        return bytes;
+    }
+
+    private static String toHex(byte[] bytes) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < bytes.length; i++) {
+            if (i > 0) {
+                sb.append(' ');
+            }
+            sb.append(String.format("%02X", bytes[i] & 0xff));
+        }
+        return sb.toString();
+    }
+
+    private static McpSchema.CallToolResult textResult(String message) {
+        return McpSchema.CallToolResult.builder()
+            .addTextContent(message)
+            .build();
+    }
+}


### PR DESCRIPTION
Generated with GPT Codex. Tested on Ghidra 12.0.0 and 12.0.4 on Manjaro against my own binary (GPT 5.3-medium) and it worked fine. I have skimmed over the code and it seemed fine.