### PR TITLE
Add Auto Analysis, Script, and Project Lifecycle MCP Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,8 +202,8 @@ GhidrAssistMCP provides 49 tools organized into categories. Several tools use an
 | `get_current_function` | Get function at current cursor position |
 | `get_function_stack_layout` | Get stack frame layout with variable offsets |
 | `get_basic_blocks` | Get basic block information for a function |
-| `create_function` | Create/define a function at an address |
-| `disassemble_at` | Disassemble code at an address |
+| `create_function` | Create/define a function at an address, optionally clearing existing data/code first |
+| `disassemble_at` | Disassemble code at an address, optionally clearing existing data/code in the range first |
 
 ### Binary Information
 
@@ -522,6 +522,23 @@ Equivalent form:
     "arguments": {
       "address": "0x00401000",
       "name": "mainWndProc"
+    }
+  }
+}
+```
+
+For overlays or mixed code/data regions where Ghidra defined code as data, clear the existing code unit or an explicit range first:
+
+```json
+{
+  "method": "tools/call",
+  "params": {
+    "name": "create_function",
+    "arguments": {
+      "address": "0x80012340",
+      "name": "ovl_init",
+      "clear_existing": true,
+      "clear_length": 256
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ GhidrAssistMCP bridges the gap between AI-powered analysis tools and Ghidra's co
 
 - **MCP Server Integration**: Full Model Context Protocol server implementation using official SDK
 - **Dual HTTP Transports**: Supports SSE and Streamable HTTP transports for maximum client compatibility
-- **38 Built-in Tools**: Comprehensive set of analysis tools with action-based consolidation for cleaner APIs
+- **47 Built-in Tools**: Comprehensive set of analysis tools with action-based consolidation for cleaner APIs
 - **6 MCP Resources**: Static data resources for program info, functions, strings, imports, exports, and segments
 - **7 MCP Prompts**: Pre-built analysis prompts for common reverse engineering tasks
 - **Result Caching**: Intelligent caching system to improve performance for repeated queries
@@ -98,7 +98,7 @@ Shameless self-promotion: [GhidrAssist](https://github.com/jtang613/GhidrAssist)
 
 The Configuration tab allows you to:
 
-- **View all available tools** (38 total)
+- **View all available tools** (47 total)
 - **Enable/disable individual tools** using checkboxes
 - **Save configuration** to persist across sessions
 - **Monitor tool status** in real-time
@@ -163,7 +163,7 @@ The headless MCP server runs inside the `analyzeHeadless` JVM and uses the loade
 
 ## Available Tools
 
-GhidrAssistMCP provides 38 tools organized into categories. Several tools use an action-based API pattern where a single tool provides multiple related operations.
+GhidrAssistMCP provides 47 tools organized into categories. Several tools use an action-based API pattern where a single tool provides multiple related operations.
 
 ### Binary & Program Management
 
@@ -171,11 +171,23 @@ GhidrAssistMCP provides 38 tools organized into categories. Several tools use an
 | ---- | ----------- |
 | `get_binary_info` | Get basic program information (name, architecture, compiler, etc.) |
 | `list_binaries` | List all open programs across all CodeBrowser windows |
+| `open_program` | List/open project programs in CodeBrowser, with optional analysis prompt suppression and analysis-after-open task submission |
+| `import_file` | Import a host file into the current Ghidra project and optionally open it *(disabled by default)* |
+| `project_files` | List or delete files/folders in the active Ghidra project; deletion requires `confirm=true` |
 | `assemble_code` | Assemble instruction text at an address and optionally patch it into program memory |
 | `patch_bytes` | Patch raw bytes in program memory at a given address |
 | `export_program` | Export the current program to disk (`binary` or `original_file`) *(disabled by default)* |
 
 > **Security-sensitive tools:** `import_file` and `export_program` are disabled by default because they interact with the host filesystem. Enable them explicitly in the plugin configuration UI when needed.
+> `project_files` deletes entries from the active Ghidra project database, not the original imported host files, and requires `confirm=true`.
+
+### Auto Analysis
+
+| Tool | Description |
+| ---- | ----------- |
+| `analysis_options` | List/set/reset Auto Analysis options and save/apply/list/delete option presets for the current program |
+| `analyze_program` | Run Auto Analysis on the current program or all open programs; supports full re-analysis, pending-changes analysis, address ranges, and option overrides |
+| `analysis_control` | Query Auto Analysis status or request cancellation of queued analysis tasks |
 
 ### Function Discovery & Analysis
 
@@ -634,7 +646,7 @@ GhidrAssistMCP/
 │   ├── TraceNetworkDataPrompt.java
 │   ├── CompareFunctionsPrompt.java
 │   └── ReverseEngineerStructPrompt.java
-└── tools/                    # MCP Tools (35 total)
+└── tools/                    # MCP Tools (47 total)
     ├── Consolidated action-based tools
     ├── Analysis tools
     ├── Modification tools
@@ -654,6 +666,9 @@ GhidrAssistMCP/
 - `types`: `action: list|get|set|create_struct|create_enum|create_typedef|delete`
 - `bookmarks`: `action: list|set|remove`
 - `xrefs`: `address|function` with `include_calls` parameter
+- `analysis_options`: `action: list|set|reset|save_preset|apply_preset|list_presets|delete_preset`
+- `analysis_control`: `action: status|cancel`
+- `project_files`: `action: list|delete`
 
 **Tool Interface Methods**:
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ GhidrAssistMCP bridges the gap between AI-powered analysis tools and Ghidra's co
 
 - **MCP Server Integration**: Full Model Context Protocol server implementation using official SDK
 - **Dual HTTP Transports**: Supports SSE and Streamable HTTP transports for maximum client compatibility
-- **47 Built-in Tools**: Comprehensive set of analysis tools with action-based consolidation for cleaner APIs
+- **48 Built-in Tools**: Comprehensive set of analysis tools with action-based consolidation for cleaner APIs
 - **6 MCP Resources**: Static data resources for program info, functions, strings, imports, exports, and segments
 - **7 MCP Prompts**: Pre-built analysis prompts for common reverse engineering tasks
 - **Result Caching**: Intelligent caching system to improve performance for repeated queries
@@ -98,7 +98,7 @@ Shameless self-promotion: [GhidrAssist](https://github.com/jtang613/GhidrAssist)
 
 The Configuration tab allows you to:
 
-- **View all available tools** (47 total)
+- **View all available tools** (48 total)
 - **Enable/disable individual tools** using checkboxes
 - **Save configuration** to persist across sessions
 - **Monitor tool status** in real-time
@@ -163,7 +163,7 @@ The headless MCP server runs inside the `analyzeHeadless` JVM and uses the loade
 
 ## Available Tools
 
-GhidrAssistMCP provides 48 tools organized into categories. Several tools use an action-based API pattern where a single tool provides multiple related operations.
+GhidrAssistMCP provides 49 tools organized into categories. Several tools use an action-based API pattern where a single tool provides multiple related operations.
 
 ### Binary & Program Management
 
@@ -175,11 +175,12 @@ GhidrAssistMCP provides 48 tools organized into categories. Several tools use an
 | `close_program` | Close an open CodeBrowser program; changed programs require `save=true` or `ignore_changes=true` |
 | `import_file` | Import a host file into the current Ghidra project and optionally open it *(disabled by default)* |
 | `project_files` | List or delete files/folders in the active Ghidra project; deletion requires `confirm=true` |
+| `scripts` | List/read/create/delete/run Ghidra scripts *(disabled by default)* |
 | `assemble_code` | Assemble instruction text at an address and optionally patch it into program memory |
 | `patch_bytes` | Patch raw bytes in program memory at a given address |
 | `export_program` | Export the current program to disk (`binary` or `original_file`) *(disabled by default)* |
 
-> **Security-sensitive tools:** `import_file` and `export_program` are disabled by default because they interact with the host filesystem. Enable them explicitly in the plugin configuration UI when needed.
+> **Security-sensitive tools:** `import_file`, `scripts`, and `export_program` are disabled by default because they interact with the host filesystem or execute script code. Enable them explicitly in the plugin configuration UI when needed.
 > `project_files` deletes entries from the active Ghidra project database, not the original imported host files, and requires `confirm=true`.
 
 ### Auto Analysis
@@ -647,7 +648,7 @@ GhidrAssistMCP/
 │   ├── TraceNetworkDataPrompt.java
 │   ├── CompareFunctionsPrompt.java
 │   └── ReverseEngineerStructPrompt.java
-└── tools/                    # MCP Tools (47 total)
+└── tools/                    # MCP Tools (48 total)
     ├── Consolidated action-based tools
     ├── Analysis tools
     ├── Modification tools
@@ -670,6 +671,7 @@ GhidrAssistMCP/
 - `analysis_options`: `action: list|set|reset|save_preset|apply_preset|list_presets|delete_preset`
 - `analysis_control`: `action: status|cancel`
 - `project_files`: `action: list|delete`
+- `scripts`: `action: list|get|create|delete|run`
 
 **Tool Interface Methods**:
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ The headless MCP server runs inside the `analyzeHeadless` JVM and uses the loade
 
 ## Available Tools
 
-GhidrAssistMCP provides 47 tools organized into categories. Several tools use an action-based API pattern where a single tool provides multiple related operations.
+GhidrAssistMCP provides 48 tools organized into categories. Several tools use an action-based API pattern where a single tool provides multiple related operations.
 
 ### Binary & Program Management
 
@@ -172,6 +172,7 @@ GhidrAssistMCP provides 47 tools organized into categories. Several tools use an
 | `get_binary_info` | Get basic program information (name, architecture, compiler, etc.) |
 | `list_binaries` | List all open programs across all CodeBrowser windows |
 | `open_program` | List/open project programs in CodeBrowser, with optional analysis prompt suppression and analysis-after-open task submission |
+| `close_program` | Close an open CodeBrowser program; changed programs require `save=true` or `ignore_changes=true` |
 | `import_file` | Import a host file into the current Ghidra project and optionally open it *(disabled by default)* |
 | `project_files` | List or delete files/folders in the active Ghidra project; deletion requires `confirm=true` |
 | `assemble_code` | Assemble instruction text at an address and optionally patch it into program memory |

--- a/src/main/java/ghidrassistmcp/GhidrAssistMCPBackend.java
+++ b/src/main/java/ghidrassistmcp/GhidrAssistMCPBackend.java
@@ -27,6 +27,9 @@ import ghidrassistmcp.resources.McpResource;
 import ghidrassistmcp.resources.McpResourceRegistry;
 import ghidrassistmcp.resources.ProgramInfoResource;
 import ghidrassistmcp.resources.StringsResource;
+import ghidrassistmcp.tools.AnalysisControlTool;
+import ghidrassistmcp.tools.AnalysisOptionsTool;
+import ghidrassistmcp.tools.AnalyzeProgramTool;
 import ghidrassistmcp.tasks.McpTask;
 import ghidrassistmcp.tasks.McpTaskManager;
 import ghidrassistmcp.tools.AssembleCodeTool;
@@ -152,6 +155,11 @@ public class GhidrAssistMCPBackend implements McpBackend {
         registerTool(new OpenProgramTool());          // open_program: open/list project files in CodeBrowser
         registerTool(new AssembleCodeTool());         // assemble_code: assemble instructions and optionally patch bytes
         registerTool(new PatchBytesTool());           // patch_bytes: write patched bytes into program memory
+
+        // Register Auto Analysis tools
+        registerTool(new AnalysisOptionsTool());      // analysis_options: list/set/reset/save/apply presets
+        registerTool(new AnalyzeProgramTool());       // analyze_program: run Auto Analysis
+        registerTool(new AnalysisControlTool());      // analysis_control: status/cancel queued analysis
 
         // Register tools that are disabled by default (security-sensitive)
         registerTool(new ImportFileTool());
@@ -341,9 +349,10 @@ public class GhidrAssistMCPBackend implements McpBackend {
         // Create a reference to this backend for the async execution
         final GhidrAssistMCPBackend backend = this;
 
-        McpTask task = taskManager.submitTask(toolName, arguments, () -> {
+        McpTask task = taskManager.submitTask(toolName, arguments, taskContext -> {
             try {
-                McpSchema.CallToolResult result = tool.execute(arguments, targetProgram, backend);
+                McpSchema.CallToolResult result =
+                    tool.execute(arguments, targetProgram, backend, taskContext);
                 result = addActiveContextToResult(result, targetProgram);
                 notifyToolResponse(toolName, result);
                 return result;

--- a/src/main/java/ghidrassistmcp/GhidrAssistMCPBackend.java
+++ b/src/main/java/ghidrassistmcp/GhidrAssistMCPBackend.java
@@ -56,6 +56,7 @@ import ghidrassistmcp.tools.GetFunctionStackLayoutTool;
 import ghidrassistmcp.tools.GetFunctionStatisticsTool;
 import ghidrassistmcp.tools.GetHexdumpTool;
 import ghidrassistmcp.tools.GetTaskStatusTool;
+import ghidrassistmcp.tools.GhidraScriptsTool;
 import ghidrassistmcp.tools.ListDataTool;
 import ghidrassistmcp.tools.ListExportsTool;
 import ghidrassistmcp.tools.ListProgramsTool;
@@ -168,6 +169,8 @@ public class GhidrAssistMCPBackend implements McpBackend {
         // Register tools that are disabled by default (security-sensitive)
         registerTool(new ImportFileTool());
         toolEnabledStates.put("import_file", false); // disabled by default: exposes host file-system read access
+        registerTool(new GhidraScriptsTool());
+        toolEnabledStates.put("scripts", false); // disabled by default: creates/deletes/runs host-side Ghidra scripts
         registerTool(new ExportProgramTool());
         toolEnabledStates.put("export_program", false); // disabled by default: writes files to host filesystem
 

--- a/src/main/java/ghidrassistmcp/GhidrAssistMCPBackend.java
+++ b/src/main/java/ghidrassistmcp/GhidrAssistMCPBackend.java
@@ -36,6 +36,7 @@ import ghidrassistmcp.tools.AssembleCodeTool;
 import ghidrassistmcp.tools.BookmarksTool;
 import ghidrassistmcp.tools.CancelTaskTool;
 import ghidrassistmcp.tools.ClassTool;
+import ghidrassistmcp.tools.CloseProgramTool;
 import ghidrassistmcp.tools.CommentsTool;
 import ghidrassistmcp.tools.CreateDataVarTool;
 import ghidrassistmcp.tools.CreateFunctionTool;
@@ -43,6 +44,7 @@ import ghidrassistmcp.tools.DisassembleAtTool;
 import ghidrassistmcp.tools.GetBasicBlocksTool;
 import ghidrassistmcp.tools.ImportFileTool;
 import ghidrassistmcp.tools.OpenProgramTool;
+import ghidrassistmcp.tools.ProjectFilesTool;
 import ghidrassistmcp.tools.ExportProgramTool;
 import ghidrassistmcp.tools.GetCodeTool;
 import ghidrassistmcp.tools.GetCurrentAddressTool;
@@ -153,6 +155,8 @@ public class GhidrAssistMCPBackend implements McpBackend {
 
         // Register project-level tools
         registerTool(new OpenProgramTool());          // open_program: open/list project files in CodeBrowser
+        registerTool(new CloseProgramTool());         // close_program: close open programs in CodeBrowser
+        registerTool(new ProjectFilesTool());         // project_files: list/delete project files and folders
         registerTool(new AssembleCodeTool());         // assemble_code: assemble instructions and optionally patch bytes
         registerTool(new PatchBytesTool());           // patch_bytes: write patched bytes into program memory
 

--- a/src/main/java/ghidrassistmcp/McpTool.java
+++ b/src/main/java/ghidrassistmcp/McpTool.java
@@ -6,6 +6,7 @@ package ghidrassistmcp;
 import java.util.Map;
 
 import ghidra.program.model.listing.Program;
+import ghidrassistmcp.tasks.McpTask;
 import io.modelcontextprotocol.spec.McpSchema;
 
 /**
@@ -42,6 +43,14 @@ public interface McpTool {
     default McpSchema.CallToolResult execute(Map<String, Object> arguments, Program currentProgram, GhidrAssistMCPBackend backend) {
         // Default implementation delegates to the original method for backward compatibility
         return execute(arguments, currentProgram);
+    }
+
+    /**
+     * Execute the tool with async task context for progress reporting.
+     */
+    default McpSchema.CallToolResult execute(Map<String, Object> arguments, Program currentProgram,
+                                             GhidrAssistMCPBackend backend, McpTask task) {
+        return execute(arguments, currentProgram, backend);
     }
 
     // ==================== MCP 2025-11-25 Tool Annotations ====================

--- a/src/main/java/ghidrassistmcp/tasks/McpTaskManager.java
+++ b/src/main/java/ghidrassistmcp/tasks/McpTaskManager.java
@@ -13,6 +13,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -62,6 +63,11 @@ public class McpTaskManager {
      */
     public McpTask submitTask(String toolName, Map<String, Object> arguments,
                                Supplier<McpSchema.CallToolResult> taskExecutor) {
+        return submitTask(toolName, arguments, task -> taskExecutor.get());
+    }
+
+    public McpTask submitTask(String toolName, Map<String, Object> arguments,
+                               Function<McpTask, McpSchema.CallToolResult> taskExecutor) {
         // Clean up old tasks before creating new ones
         cleanupOldTasks();
 
@@ -73,7 +79,7 @@ public class McpTaskManager {
                 task.markStarted();
                 Msg.info(this, "Task started: " + task.getTaskId() + " for tool: " + toolName);
 
-                McpSchema.CallToolResult result = taskExecutor.get();
+                McpSchema.CallToolResult result = taskExecutor.apply(task);
                 task.markCompleted(result);
 
                 Msg.info(this, "Task completed: " + task.getTaskId() + " in " + task.getDurationMillis() + "ms");

--- a/src/main/java/ghidrassistmcp/tasks/McpTaskMonitor.java
+++ b/src/main/java/ghidrassistmcp/tasks/McpTaskMonitor.java
@@ -1,0 +1,171 @@
+package ghidrassistmcp.tasks;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import ghidra.util.exception.CancelledException;
+import ghidra.util.task.CancelledListener;
+import ghidra.util.task.TaskMonitor;
+
+public class McpTaskMonitor implements TaskMonitor {
+
+    private final McpTask task;
+    private final int minPercent;
+    private final int maxPercent;
+    private final String prefix;
+    private final List<CancelledListener> listeners = new CopyOnWriteArrayList<>();
+
+    private volatile boolean cancelled;
+    private volatile boolean cancelEnabled = true;
+    private volatile boolean indeterminate = true;
+    private volatile boolean showProgressValue = true;
+    private volatile long maximum = NO_PROGRESS_VALUE;
+    private volatile long progress;
+    private volatile String message = "";
+
+    public McpTaskMonitor(McpTask task, int minPercent, int maxPercent, String prefix) {
+        this.task = task;
+        this.minPercent = Math.max(0, Math.min(100, minPercent));
+        this.maxPercent = Math.max(this.minPercent, Math.min(100, maxPercent));
+        this.prefix = prefix != null ? prefix : "";
+        publish();
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled || task.getStatus() == McpTask.Status.CANCELLED ||
+            Thread.currentThread().isInterrupted();
+    }
+
+    @Override
+    public void setShowProgressValue(boolean showProgressValue) {
+        this.showProgressValue = showProgressValue;
+    }
+
+    @Override
+    public void setMessage(String message) {
+        this.message = message != null ? message : "";
+        publish();
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public void setProgress(long value) {
+        progress = Math.max(0, value);
+        publish();
+    }
+
+    @Override
+    public void initialize(long max) {
+        maximum = max;
+        progress = 0;
+        indeterminate = max <= 0;
+        publish();
+    }
+
+    @Override
+    public void setMaximum(long max) {
+        maximum = max;
+        indeterminate = max <= 0;
+        publish();
+    }
+
+    @Override
+    public long getMaximum() {
+        return maximum;
+    }
+
+    @Override
+    public void setIndeterminate(boolean indeterminate) {
+        this.indeterminate = indeterminate;
+        publish();
+    }
+
+    @Override
+    public boolean isIndeterminate() {
+        return indeterminate;
+    }
+
+    @Override
+    public void checkCanceled() throws CancelledException {
+        if (isCancelled()) {
+            throw new CancelledException();
+        }
+    }
+
+    @Override
+    public void incrementProgress(long incrementAmount) {
+        setProgress(progress + incrementAmount);
+    }
+
+    @Override
+    public long getProgress() {
+        return progress;
+    }
+
+    @Override
+    public void cancel() {
+        if (!cancelEnabled || cancelled) {
+            return;
+        }
+        cancelled = true;
+        for (CancelledListener listener : listeners) {
+            listener.cancelled();
+        }
+        publish();
+    }
+
+    @Override
+    public void addCancelledListener(CancelledListener listener) {
+        if (listener != null) {
+            listeners.add(listener);
+        }
+    }
+
+    @Override
+    public void removeCancelledListener(CancelledListener listener) {
+        listeners.remove(listener);
+    }
+
+    @Override
+    public void setCancelEnabled(boolean enable) {
+        cancelEnabled = enable;
+    }
+
+    @Override
+    public boolean isCancelEnabled() {
+        return cancelEnabled;
+    }
+
+    @Override
+    public void clearCanceled() {
+        cancelled = false;
+        publish();
+    }
+
+    private void publish() {
+        task.updateProgress(mappedPercent(), displayMessage());
+    }
+
+    private int mappedPercent() {
+        if (indeterminate || maximum <= 0) {
+            return minPercent;
+        }
+        long boundedProgress = Math.max(0, Math.min(progress, maximum));
+        double fraction = maximum == 0 ? 0.0 : (double) boundedProgress / (double) maximum;
+        return minPercent + (int) Math.round((maxPercent - minPercent) * fraction);
+    }
+
+    private String displayMessage() {
+        String suffix = message.isBlank() ? "" : " - " + message;
+        if (!showProgressValue || indeterminate || maximum <= 0) {
+            return prefix + suffix;
+        }
+        long boundedProgress = Math.max(0, Math.min(progress, maximum));
+        return prefix + suffix + " (" + boundedProgress + "/" + maximum + ")";
+    }
+}

--- a/src/main/java/ghidrassistmcp/tools/AnalysisControlTool.java
+++ b/src/main/java/ghidrassistmcp/tools/AnalysisControlTool.java
@@ -1,0 +1,126 @@
+package ghidrassistmcp.tools;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import ghidra.app.plugin.core.analysis.AutoAnalysisManager;
+import ghidra.program.model.listing.Program;
+import ghidrassistmcp.GhidrAssistMCPBackend;
+import ghidrassistmcp.McpTool;
+import io.modelcontextprotocol.spec.McpSchema;
+
+public class AnalysisControlTool implements McpTool {
+
+    @Override
+    public String getName() {
+        return "analysis_control";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Check Auto Analysis status or request cancellation of queued analysis for current/specified/all open programs. " +
+            "Use MCP task tools (get_task_status/cancel_task) for analyze_program task tracking.";
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        return false;
+    }
+
+    @Override
+    public McpSchema.JsonSchema getInputSchema() {
+        return new McpSchema.JsonSchema("object",
+            Map.ofEntries(
+                Map.entry("action", Map.of(
+                    "type", "string",
+                    "description", "Operation to perform",
+                    "enum", List.of("status", "cancel")
+                )),
+                Map.entry("scope", Map.of(
+                    "type", "string",
+                    "description", "Program scope. Default: current",
+                    "enum", List.of("current", "all_open"),
+                    "default", "current"
+                ))
+            ),
+            List.of("action"), null, null, null);
+    }
+
+    @Override
+    public McpSchema.CallToolResult execute(Map<String, Object> arguments, Program currentProgram) {
+        return execute(arguments, currentProgram, null);
+    }
+
+    @Override
+    public McpSchema.CallToolResult execute(Map<String, Object> arguments, Program currentProgram,
+                                            GhidrAssistMCPBackend backend) {
+        String action = (String) arguments.get("action");
+        if (action == null || action.isBlank()) {
+            return textResult("action is required: status or cancel.");
+        }
+
+        List<Program> programs = resolvePrograms(arguments, currentProgram, backend);
+        if (programs.isEmpty()) {
+            return textResult("No program currently loaded.");
+        }
+
+        String normalizedAction = action.trim().toLowerCase();
+        return switch (normalizedAction) {
+            case "status" -> status(programs);
+            case "cancel" -> cancel(programs);
+            default -> textResult("Invalid action: " + action + ". Use status or cancel.");
+        };
+    }
+
+    private McpSchema.CallToolResult status(List<Program> programs) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Auto Analysis Status\n\n");
+        for (Program program : programs) {
+            boolean hasManager = AutoAnalysisManager.hasAutoAnalysisManager(program);
+            boolean analyzing = hasManager && AutoAnalysisManager.getAnalysisManager(program).isAnalyzing();
+            sb.append("- ").append(program.getName()).append("\n");
+            sb.append("  Analysis Manager Initialized: ").append(hasManager).append("\n");
+            sb.append("  Is Analyzing: ").append(analyzing).append("\n");
+            sb.append("  Analyzed Flag: ").append(AnalysisUtils.isAnalyzed(program)).append("\n");
+            sb.append("  Should Ask To Analyze: ").append(AnalysisUtils.shouldAskToAnalyze(program)).append("\n");
+        }
+        return textResult(sb.toString().trim());
+    }
+
+    private McpSchema.CallToolResult cancel(List<Program> programs) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Auto Analysis Cancellation\n\n");
+        for (Program program : programs) {
+            if (!AutoAnalysisManager.hasAutoAnalysisManager(program)) {
+                sb.append("- ").append(program.getName()).append(": analysis manager not initialized\n");
+                continue;
+            }
+            AutoAnalysisManager manager = AutoAnalysisManager.getAnalysisManager(program);
+            manager.cancelQueuedTasks();
+            sb.append("- ").append(program.getName())
+              .append(": requested cancellation of queued analysis tasks. ")
+              .append("An active analyzer may continue until its current monitor observes cancellation.\n");
+        }
+        return textResult(sb.toString().trim());
+    }
+
+    private List<Program> resolvePrograms(Map<String, Object> arguments, Program currentProgram,
+                                          GhidrAssistMCPBackend backend) {
+        String scope = (String) arguments.get("scope");
+        if ("all_open".equalsIgnoreCase(scope) && backend != null) {
+            return backend.getAllOpenPrograms();
+        }
+        List<Program> result = new ArrayList<>();
+        if (currentProgram != null) {
+            result.add(currentProgram);
+        }
+        return result;
+    }
+
+    private McpSchema.CallToolResult textResult(String message) {
+        return McpSchema.CallToolResult.builder()
+            .addTextContent(message)
+            .build();
+    }
+}

--- a/src/main/java/ghidrassistmcp/tools/AnalysisOptionsTool.java
+++ b/src/main/java/ghidrassistmcp/tools/AnalysisOptionsTool.java
@@ -1,0 +1,347 @@
+package ghidrassistmcp.tools;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.TreeSet;
+
+import ghidra.framework.preferences.Preferences;
+import ghidra.program.model.listing.Program;
+import ghidrassistmcp.GhidrAssistMCPBackend;
+import ghidrassistmcp.McpTool;
+import io.modelcontextprotocol.spec.McpSchema;
+
+public class AnalysisOptionsTool implements McpTool {
+
+    private static final String PRESET_PREFIX = "GhidrAssistMCP.AnalysisPreset.";
+
+    @Override
+    public String getName() {
+        return "analysis_options";
+    }
+
+    @Override
+    public String getDescription() {
+        return "List, set, reset, save, and apply Ghidra Auto Analysis options. " +
+            "Plugin-provided Auto Analyzers appear here when their analyzers are registered for the program.";
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        return false;
+    }
+
+    @Override
+    public boolean isIdempotent() {
+        return false;
+    }
+
+    @Override
+    public McpSchema.JsonSchema getInputSchema() {
+        return new McpSchema.JsonSchema("object",
+            Map.ofEntries(
+                Map.entry("action", Map.of(
+                    "type", "string",
+                    "description", "Operation to perform",
+                    "enum", List.of("list", "set", "reset", "save_preset", "apply_preset", "list_presets", "delete_preset")
+                )),
+                Map.entry("filter", Map.of(
+                    "type", "string",
+                    "description", "For action='list': optional case-insensitive substring filter for option names"
+                )),
+                Map.entry("offset", Map.of(
+                    "type", "integer",
+                    "description", "For action='list': number of matching options to skip. Default: 0",
+                    "default", 0,
+                    "minimum", 0
+                )),
+                Map.entry("limit", Map.of(
+                    "type", "integer",
+                    "description", "For action='list': maximum options to return. Default: 200",
+                    "default", 200,
+                    "minimum", 1
+                )),
+                Map.entry("options", Map.of(
+                    "type", "object",
+                    "description", "For action='set' or 'save_preset': mapping of analysis option names to values"
+                )),
+                Map.entry("option_names", Map.of(
+                    "type", "array",
+                    "description", "For action='reset' or 'save_preset': list of analysis option names",
+                    "items", Map.of("type", "string")
+                )),
+                Map.entry("preset_name", Map.of(
+                    "type", "string",
+                    "description", "Preset name for save_preset/apply_preset/delete_preset"
+                ))
+            ),
+            List.of("action"), null, null, null);
+    }
+
+    @Override
+    public McpSchema.CallToolResult execute(Map<String, Object> arguments, Program currentProgram) {
+        return execute(arguments, currentProgram, null);
+    }
+
+    @Override
+    public McpSchema.CallToolResult execute(Map<String, Object> arguments, Program currentProgram,
+                                            GhidrAssistMCPBackend backend) {
+        String action = (String) arguments.get("action");
+        if (action == null || action.isBlank()) {
+            return textResult("action is required.");
+        }
+
+        String normalizedAction = action.trim().toLowerCase();
+        if ("list_presets".equals(normalizedAction)) {
+            return listPresets();
+        }
+
+        if (currentProgram == null) {
+            return textResult("No program currently loaded.");
+        }
+
+        return switch (normalizedAction) {
+            case "list" -> listOptions(arguments, currentProgram);
+            case "set" -> setOptions(arguments, currentProgram, backend);
+            case "reset" -> resetOptions(arguments, currentProgram, backend);
+            case "save_preset" -> savePreset(arguments, currentProgram);
+            case "apply_preset" -> applyPreset(arguments, currentProgram, backend);
+            case "delete_preset" -> deletePreset(arguments);
+            default -> textResult("Invalid action: " + action +
+                ". Use list, set, reset, save_preset, apply_preset, list_presets, or delete_preset.");
+        };
+    }
+
+    private McpSchema.CallToolResult listOptions(Map<String, Object> arguments, Program program) {
+        String filter = (String) arguments.get("filter");
+        String normalizedFilter = filter != null ? filter.toLowerCase() : null;
+        int offset = numberArg(arguments.get("offset"), 0);
+        int limit = numberArg(arguments.get("limit"), 200);
+
+        List<AnalysisUtils.OptionSnapshot> allOptions = AnalysisUtils.listAnalysisOptions(program);
+        List<AnalysisUtils.OptionSnapshot> matches = allOptions.stream()
+            .filter(o -> normalizedFilter == null || o.name.toLowerCase().contains(normalizedFilter))
+            .toList();
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("Auto Analysis Options for ").append(program.getName()).append("\n\n");
+        sb.append("Analyzed Flag: ").append(AnalysisUtils.isAnalyzed(program)).append("\n");
+        sb.append("Should Ask To Analyze: ").append(AnalysisUtils.shouldAskToAnalyze(program)).append("\n\n");
+
+        int end = Math.min(matches.size(), offset + limit);
+        for (int i = offset; i < end; i++) {
+            AnalysisUtils.OptionSnapshot option = matches.get(i);
+            sb.append("- ").append(option.name).append("\n");
+            sb.append("  Type: ").append(option.type).append("\n");
+            sb.append("  Value: ").append(option.value);
+            if (option.isDefault) {
+                sb.append(" (default)");
+            }
+            sb.append("\n");
+            sb.append("  Default: ").append(option.defaultValue).append("\n");
+            if (!option.description.isBlank()) {
+                sb.append("  Description: ").append(option.description).append("\n");
+            }
+        }
+
+        sb.append("\nShowing ").append(Math.max(0, end - offset))
+          .append(" of ").append(matches.size()).append(" matching option(s)");
+        if (offset > 0) {
+            sb.append(" (offset ").append(offset).append(")");
+        }
+        sb.append("\nTotal registered analysis options: ").append(allOptions.size());
+
+        return textResult(sb.toString());
+    }
+
+    private McpSchema.CallToolResult setOptions(Map<String, Object> arguments, Program program,
+                                                GhidrAssistMCPBackend backend) {
+        Map<String, Object> options = AnalysisUtils.objectMap(arguments.get("options"));
+        if (options == null || options.isEmpty()) {
+            return textResult("options object is required for action='set'.");
+        }
+
+        List<String> errors = AnalysisUtils.applyAnalysisOptions(program, options);
+        if (!errors.isEmpty()) {
+            return textResult("Failed to set analysis options:\n- " + String.join("\n- ", errors));
+        }
+        if (backend != null) {
+            backend.clearCache();
+        }
+        return textResult("Set " + options.size() + " analysis option(s) for " + program.getName() + ".");
+    }
+
+    private McpSchema.CallToolResult resetOptions(Map<String, Object> arguments, Program program,
+                                                  GhidrAssistMCPBackend backend) {
+        List<String> names = AnalysisUtils.stringList(arguments.get("option_names"));
+        List<String> errors = AnalysisUtils.resetAnalysisOptions(program, names);
+        if (!errors.isEmpty()) {
+            return textResult("Failed to reset analysis options:\n- " + String.join("\n- ", errors));
+        }
+        if (backend != null) {
+            backend.clearCache();
+        }
+        if (names == null || names.isEmpty()) {
+            return textResult("Reset all analysis options to defaults for " + program.getName() + ".");
+        }
+        return textResult("Reset " + names.size() + " analysis option(s) for " + program.getName() + ".");
+    }
+
+    private McpSchema.CallToolResult savePreset(Map<String, Object> arguments, Program program) {
+        String presetName = normalizePresetName(arguments.get("preset_name"));
+        if (presetName == null) {
+            return textResult("preset_name is required and may not contain ',' or newlines.");
+        }
+
+        Map<String, Object> explicitOptions = AnalysisUtils.objectMap(arguments.get("options"));
+        List<String> optionNames = AnalysisUtils.stringList(arguments.get("option_names"));
+        Map<String, String> values = new LinkedHashMap<>();
+
+        if (explicitOptions != null && !explicitOptions.isEmpty()) {
+            for (Map.Entry<String, Object> entry : explicitOptions.entrySet()) {
+                values.put(entry.getKey(), entry.getValue() != null ? entry.getValue().toString() : "");
+            }
+        } else {
+            List<AnalysisUtils.OptionSnapshot> snapshots = AnalysisUtils.listAnalysisOptions(program);
+            for (AnalysisUtils.OptionSnapshot snapshot : snapshots) {
+                if (optionNames == null || optionNames.isEmpty() || optionNames.contains(snapshot.name)) {
+                    values.put(snapshot.name, snapshot.value);
+                }
+            }
+        }
+
+        if (values.isEmpty()) {
+            return textResult("No analysis options selected for preset '" + presetName + "'.");
+        }
+
+        Properties properties = new Properties();
+        for (Map.Entry<String, String> entry : values.entrySet()) {
+            properties.setProperty(entry.getKey(), entry.getValue());
+        }
+
+        try {
+            StringWriter writer = new StringWriter();
+            properties.store(writer, "GhidrAssistMCP analysis preset");
+            Preferences.setProperty(PRESET_PREFIX + presetName, writer.toString());
+            Preferences.store();
+            return textResult("Saved analysis preset '" + presetName + "' with " + values.size() + " option(s).");
+        } catch (IOException e) {
+            return textResult("Failed to save preset '" + presetName + "': " + e.getMessage());
+        }
+    }
+
+    private McpSchema.CallToolResult applyPreset(Map<String, Object> arguments, Program program,
+                                                 GhidrAssistMCPBackend backend) {
+        String presetName = normalizePresetName(arguments.get("preset_name"));
+        if (presetName == null) {
+            return textResult("preset_name is required.");
+        }
+
+        Properties properties = loadPreset(presetName);
+        if (properties == null) {
+            return textResult("Analysis preset not found: " + presetName);
+        }
+
+        Map<String, Object> options = new LinkedHashMap<>();
+        for (String name : properties.stringPropertyNames()) {
+            options.put(name, properties.getProperty(name));
+        }
+
+        List<String> errors = AnalysisUtils.applyAnalysisOptions(program, options);
+        if (!errors.isEmpty()) {
+            return textResult("Failed to apply analysis preset '" + presetName + "':\n- " +
+                String.join("\n- ", errors));
+        }
+        if (backend != null) {
+            backend.clearCache();
+        }
+        return textResult("Applied analysis preset '" + presetName + "' to " + program.getName() +
+            " (" + options.size() + " option(s)).");
+    }
+
+    private McpSchema.CallToolResult listPresets() {
+        Set<String> names = presetNames();
+        if (names.isEmpty()) {
+            return textResult("No analysis presets saved.");
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("Saved analysis presets:\n\n");
+        for (String name : names) {
+            Properties properties = loadPreset(name);
+            sb.append("- ").append(name);
+            if (properties != null) {
+                sb.append(" (").append(properties.size()).append(" option(s))");
+            }
+            sb.append("\n");
+        }
+        return textResult(sb.toString());
+    }
+
+    private McpSchema.CallToolResult deletePreset(Map<String, Object> arguments) {
+        String presetName = normalizePresetName(arguments.get("preset_name"));
+        if (presetName == null) {
+            return textResult("preset_name is required.");
+        }
+
+        String removed = Preferences.removeProperty(PRESET_PREFIX + presetName);
+        Preferences.store();
+        if (removed == null) {
+            return textResult("Analysis preset not found: " + presetName);
+        }
+        return textResult("Deleted analysis preset '" + presetName + "'.");
+    }
+
+    private Set<String> presetNames() {
+        Set<String> names = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+        for (String key : Preferences.getPropertyNames()) {
+            if (key.startsWith(PRESET_PREFIX)) {
+                names.add(key.substring(PRESET_PREFIX.length()));
+            }
+        }
+        return names;
+    }
+
+    private Properties loadPreset(String presetName) {
+        String value = Preferences.getProperty(PRESET_PREFIX + presetName);
+        if (value == null) {
+            return null;
+        }
+        Properties properties = new Properties();
+        try {
+            properties.load(new StringReader(value));
+            return properties;
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    private String normalizePresetName(Object value) {
+        if (!(value instanceof String text)) {
+            return null;
+        }
+        String trimmed = text.trim();
+        if (trimmed.isEmpty() || trimmed.contains(",") || trimmed.contains("\n") || trimmed.contains("\r")) {
+            return null;
+        }
+        return trimmed;
+    }
+
+    private int numberArg(Object value, int defaultValue) {
+        if (value instanceof Number number) {
+            return Math.max(0, number.intValue());
+        }
+        return defaultValue;
+    }
+
+    private McpSchema.CallToolResult textResult(String message) {
+        return McpSchema.CallToolResult.builder()
+            .addTextContent(message)
+            .build();
+    }
+}

--- a/src/main/java/ghidrassistmcp/tools/AnalysisUtils.java
+++ b/src/main/java/ghidrassistmcp/tools/AnalysisUtils.java
@@ -1,0 +1,461 @@
+package ghidrassistmcp.tools;
+
+import java.awt.Color;
+import java.awt.Font;
+import java.beans.PropertyEditor;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import ghidra.app.plugin.core.analysis.AutoAnalysisManager;
+import ghidra.framework.options.ActionTrigger;
+import ghidra.framework.options.CustomOption;
+import ghidra.framework.options.OptionType;
+import ghidra.framework.options.Options;
+import ghidra.program.model.address.Address;
+import ghidra.program.model.address.AddressSet;
+import ghidra.program.model.address.AddressSetView;
+import ghidra.program.model.listing.Program;
+import ghidra.util.Msg;
+import ghidra.util.task.TaskMonitor;
+import javax.swing.KeyStroke;
+
+final class AnalysisUtils {
+
+    static final String MODE_FULL = "full";
+    static final String MODE_CHANGES = "changes";
+
+    private AnalysisUtils() {
+    }
+
+    static AutoAnalysisManager getManager(Program program) {
+        return AutoAnalysisManager.getAnalysisManager(program);
+    }
+
+    static Options getAnalysisOptions(Program program) {
+        getManager(program);
+        return program.getOptions(Program.ANALYSIS_PROPERTIES);
+    }
+
+    static Options getProgramInfoOptions(Program program) {
+        return program.getOptions(Program.PROGRAM_INFO);
+    }
+
+    static String setAskToAnalyze(Program program, boolean askToAnalyze) {
+        Options options = getProgramInfoOptions(program);
+        boolean current = options.getBoolean(Program.ASK_TO_ANALYZE_OPTION_NAME, true);
+        if (current == askToAnalyze) {
+            return "Should Ask To Analyze already " + askToAnalyze;
+        }
+
+        int txId = program.startTransaction("Set Ask To Analyze");
+        boolean committed = false;
+        try {
+            options.setBoolean(Program.ASK_TO_ANALYZE_OPTION_NAME, askToAnalyze);
+            committed = true;
+            return "Set Should Ask To Analyze to " + askToAnalyze;
+        } finally {
+            program.endTransaction(txId, committed);
+        }
+    }
+
+    static boolean isAnalyzed(Program program) {
+        Options options = getProgramInfoOptions(program);
+        return options.getBoolean(Program.ANALYZED_OPTION_NAME, false);
+    }
+
+    static boolean shouldAskToAnalyze(Program program) {
+        Options options = getProgramInfoOptions(program);
+        return options.getBoolean(Program.ASK_TO_ANALYZE_OPTION_NAME, true);
+    }
+
+    static List<OptionSnapshot> listAnalysisOptions(Program program) {
+        Options options = getAnalysisOptions(program);
+        List<OptionSnapshot> snapshots = new ArrayList<>();
+        for (String name : options.getOptionNames()) {
+            OptionType type = options.getType(name);
+            String value = safeValue(options, name);
+            String defaultValue = safeDefaultValue(options, name);
+            String description = safeDescription(options, name);
+            boolean isDefault = value.equals(defaultValue);
+            snapshots.add(new OptionSnapshot(name, type.toString(), value, defaultValue,
+                description, isDefault));
+        }
+        snapshots.sort(Comparator.comparing(o -> o.name, String.CASE_INSENSITIVE_ORDER));
+        return snapshots;
+    }
+
+    static List<String> applyAnalysisOptions(Program program, Map<String, Object> optionOverrides) {
+        List<String> errors = new ArrayList<>();
+        if (optionOverrides == null || optionOverrides.isEmpty()) {
+            return errors;
+        }
+
+        Options options = getAnalysisOptions(program);
+        int txId = program.startTransaction("Set Analysis Options");
+        boolean committed = false;
+        try {
+            for (Map.Entry<String, Object> entry : optionOverrides.entrySet()) {
+                String error = setAnalysisOption(options, entry.getKey(), entry.getValue());
+                if (!error.isEmpty()) {
+                    errors.add(error);
+                }
+            }
+            committed = errors.isEmpty();
+            return errors;
+        } finally {
+            program.endTransaction(txId, committed);
+        }
+    }
+
+    static List<String> resetAnalysisOptions(Program program, List<String> optionNames) {
+        List<String> errors = new ArrayList<>();
+        Options options = getAnalysisOptions(program);
+
+        int txId = program.startTransaction("Reset Analysis Options");
+        boolean committed = false;
+        try {
+            if (optionNames == null || optionNames.isEmpty()) {
+                for (String name : options.getOptionNames()) {
+                    options.restoreDefaultValue(name);
+                }
+            } else {
+                for (String name : optionNames) {
+                    if (!options.contains(name)) {
+                        errors.add("Analysis option not found: " + name);
+                        continue;
+                    }
+                    options.restoreDefaultValue(name);
+                }
+            }
+            committed = errors.isEmpty();
+            return errors;
+        } finally {
+            program.endTransaction(txId, committed);
+        }
+    }
+
+    static String runAnalysis(Program program, String mode, AddressSetView restrictSet,
+                              Map<String, Object> optionOverrides, TaskMonitor monitor) {
+        TaskMonitor activeMonitor = monitor != null ? monitor : TaskMonitor.DUMMY;
+        activeMonitor.setMessage("Applying analysis options");
+        List<String> optionErrors = applyAnalysisOptions(program, optionOverrides);
+        if (!optionErrors.isEmpty()) {
+            return "Analysis option errors:\n- " + String.join("\n- ", optionErrors);
+        }
+
+        String normalizedMode = normalizeMode(mode);
+        AutoAnalysisManager manager = getManager(program);
+        long start = System.currentTimeMillis();
+
+        activeMonitor.setMessage("Starting analysis");
+        if (MODE_CHANGES.equals(normalizedMode)) {
+            if (restrictSet != null && !restrictSet.isEmpty()) {
+                return "mode 'changes' cannot be restricted to an address range. Use mode 'full'.";
+            }
+            manager.startAnalysis(activeMonitor);
+        } else {
+            manager.reAnalyzeAll(restrictSet);
+            manager.startAnalysis(activeMonitor);
+        }
+
+        activeMonitor.setMessage("Waiting for analysis");
+        manager.waitForAnalysis(null, activeMonitor);
+        long elapsed = System.currentTimeMillis() - start;
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("Analysis completed for ").append(program.getName()).append("\n");
+        sb.append("  Mode: ").append(normalizedMode).append("\n");
+        if (restrictSet != null && !restrictSet.isEmpty()) {
+            sb.append("  Restricted Range: ").append(restrictSet.getMinAddress())
+              .append(" - ").append(restrictSet.getMaxAddress()).append("\n");
+        } else {
+            sb.append("  Restricted Range: none\n");
+        }
+        sb.append("  Option Overrides: ")
+          .append(optionOverrides != null ? optionOverrides.size() : 0).append("\n");
+        sb.append("  Duration: ").append(elapsed).append("ms\n");
+        sb.append("  Analyzed Flag: ").append(isAnalyzed(program)).append("\n");
+        sb.append("  Should Ask To Analyze: ").append(shouldAskToAnalyze(program));
+        return sb.toString();
+    }
+
+    static String normalizeMode(String mode) {
+        if (mode == null || mode.isBlank()) {
+            return MODE_FULL;
+        }
+        String normalized = mode.trim().toLowerCase();
+        if (MODE_FULL.equals(normalized) || MODE_CHANGES.equals(normalized)) {
+            return normalized;
+        }
+        throw new IllegalArgumentException("Invalid analysis mode: " + mode + ". Use 'full' or 'changes'.");
+    }
+
+    static AddressSet parseRange(Program program, String startAddress, String endAddress) {
+        if ((startAddress == null || startAddress.isBlank()) &&
+            (endAddress == null || endAddress.isBlank())) {
+            return null;
+        }
+        if (startAddress == null || startAddress.isBlank() ||
+            endAddress == null || endAddress.isBlank()) {
+            throw new IllegalArgumentException("Both start_address and end_address are required for range analysis.");
+        }
+
+        Address start = program.getAddressFactory().getAddress(startAddress);
+        Address end = program.getAddressFactory().getAddress(endAddress);
+        if (start == null || end == null) {
+            throw new IllegalArgumentException("Invalid address range: " + startAddress + " - " + endAddress);
+        }
+        if (start.compareTo(end) > 0) {
+            throw new IllegalArgumentException("start_address must be <= end_address.");
+        }
+        return new AddressSet(start, end);
+    }
+
+    static Map<String, Object> objectMap(Object value) {
+        if (!(value instanceof Map<?, ?> rawMap)) {
+            return null;
+        }
+        Map<String, Object> result = new LinkedHashMap<>();
+        for (Map.Entry<?, ?> entry : rawMap.entrySet()) {
+            if (entry.getKey() != null) {
+                result.put(entry.getKey().toString(), entry.getValue());
+            }
+        }
+        return result;
+    }
+
+    static List<String> stringList(Object value) {
+        if (!(value instanceof List<?> rawList)) {
+            return null;
+        }
+        List<String> result = new ArrayList<>();
+        for (Object item : rawList) {
+            if (item != null) {
+                result.add(item.toString());
+            }
+        }
+        return result;
+    }
+
+    private static String setAnalysisOption(Options options, String optionName, Object optionValue) {
+        if (optionValue == null) {
+            return optionName + " cannot be set to null.";
+        }
+        if (!options.contains(optionName)) {
+            return optionName + " could not be found for this program.";
+        }
+
+        OptionType optionType = options.getType(optionName);
+        try {
+            switch (optionType) {
+                case INT_TYPE:
+                    options.setInt(optionName, asNumber(optionValue).intValue());
+                    break;
+                case LONG_TYPE:
+                    options.setLong(optionName, asNumber(optionValue).longValue());
+                    break;
+                case STRING_TYPE:
+                    options.setString(optionName, optionValue.toString());
+                    break;
+                case DOUBLE_TYPE:
+                    options.setDouble(optionName, asNumber(optionValue).doubleValue());
+                    break;
+                case FLOAT_TYPE:
+                    options.setFloat(optionName, asNumber(optionValue).floatValue());
+                    break;
+                case BOOLEAN_TYPE:
+                    options.setBoolean(optionName, asBoolean(optionValue));
+                    break;
+                case ENUM_TYPE:
+                    setEnum(options, optionName, optionValue.toString());
+                    break;
+                case KEYSTROKE_TYPE:
+                    options.setKeyStroke(optionName,
+                        (KeyStroke) convertOptionValue(options, optionName, optionType, optionValue));
+                    break;
+                case FONT_TYPE:
+                    options.setFont(optionName,
+                        (Font) convertOptionValue(options, optionName, optionType, optionValue));
+                    break;
+                case DATE_TYPE:
+                    options.setDate(optionName,
+                        (Date) convertOptionValue(options, optionName, optionType, optionValue));
+                    break;
+                case BYTE_ARRAY_TYPE:
+                    options.setByteArray(optionName, asByteArray(options, optionName, optionValue));
+                    break;
+                case COLOR_TYPE:
+                    options.setColor(optionName,
+                        (Color) convertOptionValue(options, optionName, optionType, optionValue));
+                    break;
+                case FILE_TYPE:
+                    options.setFile(optionName,
+                        (File) convertOptionValue(options, optionName, optionType, optionValue));
+                    break;
+                case ACTION_TRIGGER:
+                    options.setActionTrigger(optionName,
+                        (ActionTrigger) convertOptionValue(options, optionName, optionType, optionValue));
+                    break;
+                case CUSTOM_TYPE:
+                    Object customValue = convertOptionValue(options, optionName, optionType, optionValue);
+                    if (!(customValue instanceof CustomOption customOption)) {
+                        return "Custom option " + optionName +
+                            " could not be converted. This option requires a registered property editor " +
+                            "or a Ghidra CustomOption string representation.";
+                    }
+                    options.setCustomOption(optionName, customOption);
+                    break;
+                case NO_TYPE:
+                default:
+                    return "Unsupported analysis option type for " + optionName + ": " + optionType + ".";
+            }
+            return "";
+        } catch (NumberFormatException e) {
+            return "Could not convert '" + optionValue + "' for " + optionName + " to " + optionType + ".";
+        } catch (IllegalArgumentException e) {
+            return "Error changing option '" + optionName + "': " + e.getMessage();
+        }
+    }
+
+    private static Object convertOptionValue(Options options, String optionName, OptionType optionType,
+                                             Object optionValue) {
+        if (optionType.isCompatible(optionValue)) {
+            return optionValue;
+        }
+
+        String text = optionValue.toString();
+        PropertyEditor editor = options.getPropertyEditor(optionName);
+        if (editor == null) {
+            editor = options.getRegisteredPropertyEditor(optionName);
+        }
+        if (editor != null) {
+            try {
+                editor.setAsText(text);
+                Object editorValue = editor.getValue();
+                if (optionType.isCompatible(editorValue)) {
+                    return editorValue;
+                }
+            } catch (IllegalArgumentException e) {
+                Msg.debug(AnalysisUtils.class, "Property editor could not parse option: " + optionName, e);
+            }
+        }
+
+        Object converted = optionType.convertStringToObject(text);
+        if (!optionType.isCompatible(converted)) {
+            throw new IllegalArgumentException("Converted value for " + optionName +
+                " is not compatible with " + optionType + ".");
+        }
+        return converted;
+    }
+
+    private static byte[] asByteArray(Options options, String optionName, Object optionValue) {
+        if (optionValue instanceof byte[] bytes) {
+            return bytes;
+        }
+        if (optionValue instanceof List<?> list) {
+            byte[] bytes = new byte[list.size()];
+            for (int i = 0; i < list.size(); i++) {
+                Object item = list.get(i);
+                if (!(item instanceof Number number)) {
+                    throw new IllegalArgumentException("Byte array list values must be numbers.");
+                }
+                bytes[i] = (byte) number.intValue();
+            }
+            return bytes;
+        }
+        return (byte[]) convertOptionValue(options, optionName, OptionType.BYTE_ARRAY_TYPE, optionValue);
+    }
+
+    private static Number asNumber(Object value) {
+        if (value instanceof Number number) {
+            return number;
+        }
+        return Double.valueOf(value.toString());
+    }
+
+    private static boolean asBoolean(Object value) {
+        if (value instanceof Boolean bool) {
+            return bool;
+        }
+        String text = value.toString().trim().toLowerCase();
+        if ("true".equals(text)) {
+            return true;
+        }
+        if ("false".equals(text)) {
+            return false;
+        }
+        throw new IllegalArgumentException("Boolean value must be true or false.");
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    private static void setEnum(Options options, String optionName, String optionValue) {
+        Enum current = options.getEnum(optionName, null);
+        if (current == null) {
+            throw new IllegalArgumentException("No existing enum value is available.");
+        }
+
+        Class enumClass = current.getDeclaringClass();
+        for (Object constant : enumClass.getEnumConstants()) {
+            Enum enumValue = (Enum) constant;
+            if (enumValue.name().equals(optionValue) || enumValue.toString().equals(optionValue)) {
+                options.setEnum(optionName, enumValue);
+                return;
+            }
+        }
+        throw new IllegalArgumentException("Unknown enum value: " + optionValue);
+    }
+
+    private static String safeValue(Options options, String name) {
+        try {
+            String value = options.getValueAsString(name);
+            return value != null ? value : "";
+        } catch (Exception e) {
+            Msg.debug(AnalysisUtils.class, "Failed to read option value: " + name, e);
+            return "";
+        }
+    }
+
+    private static String safeDefaultValue(Options options, String name) {
+        try {
+            String value = options.getDefaultValueAsString(name);
+            return value != null ? value : "";
+        } catch (Exception e) {
+            Object defaultValue = options.getDefaultValue(name);
+            return defaultValue != null ? defaultValue.toString() : "";
+        }
+    }
+
+    private static String safeDescription(Options options, String name) {
+        try {
+            String description = options.getDescription(name);
+            return description != null ? description : "";
+        } catch (Exception e) {
+            Msg.debug(AnalysisUtils.class, "Failed to read option description: " + name, e);
+            return "";
+        }
+    }
+
+    static class OptionSnapshot {
+        final String name;
+        final String type;
+        final String value;
+        final String defaultValue;
+        final String description;
+        final boolean isDefault;
+
+        OptionSnapshot(String name, String type, String value, String defaultValue,
+                       String description, boolean isDefault) {
+            this.name = name;
+            this.type = type;
+            this.value = value;
+            this.defaultValue = defaultValue;
+            this.description = description;
+            this.isDefault = isDefault;
+        }
+    }
+}

--- a/src/main/java/ghidrassistmcp/tools/AnalyzeProgramTool.java
+++ b/src/main/java/ghidrassistmcp/tools/AnalyzeProgramTool.java
@@ -1,0 +1,184 @@
+package ghidrassistmcp.tools;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import ghidra.program.model.address.AddressSet;
+import ghidra.program.model.listing.Program;
+import ghidra.util.Msg;
+import ghidra.util.task.TaskMonitor;
+import ghidrassistmcp.GhidrAssistMCPBackend;
+import ghidrassistmcp.McpTool;
+import ghidrassistmcp.tasks.McpTask;
+import ghidrassistmcp.tasks.McpTaskMonitor;
+import io.modelcontextprotocol.spec.McpSchema;
+
+public class AnalyzeProgramTool implements McpTool {
+
+    @Override
+    public String getName() {
+        return "analyze_program";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Run Ghidra Auto Analysis on the current/specified program or all open programs. " +
+            "Supports full re-analysis, pending-changes analysis, optional address range restriction, " +
+            "and per-call analysis option overrides.";
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        return false;
+    }
+
+    @Override
+    public boolean isIdempotent() {
+        return false;
+    }
+
+    @Override
+    public boolean isLongRunning() {
+        return true;
+    }
+
+    @Override
+    public McpSchema.JsonSchema getInputSchema() {
+        return new McpSchema.JsonSchema("object",
+            Map.ofEntries(
+                Map.entry("scope", Map.of(
+                    "type", "string",
+                    "description", "Program scope to analyze. Default: current",
+                    "enum", List.of("current", "all_open"),
+                    "default", "current"
+                )),
+                Map.entry("mode", Map.of(
+                    "type", "string",
+                    "description", "Analysis mode. 'full' schedules all program bytes/range for re-analysis; 'changes' waits for pending analysis only. Default: full",
+                    "enum", List.of("full", "changes"),
+                    "default", "full"
+                )),
+                Map.entry("start_address", Map.of(
+                    "type", "string",
+                    "description", "Optional range start address for mode='full' on a single program"
+                )),
+                Map.entry("end_address", Map.of(
+                    "type", "string",
+                    "description", "Optional range end address for mode='full' on a single program"
+                )),
+                Map.entry("options", Map.of(
+                    "type", "object",
+                    "description", "Optional analysis option overrides to apply before analysis"
+                ))
+            ),
+            List.of(), null, null, null);
+    }
+
+    @Override
+    public McpSchema.CallToolResult execute(Map<String, Object> arguments, Program currentProgram) {
+        return execute(arguments, currentProgram, null);
+    }
+
+    @Override
+    public McpSchema.CallToolResult execute(Map<String, Object> arguments, Program currentProgram,
+                                            GhidrAssistMCPBackend backend) {
+        return executeInternal(arguments, currentProgram, backend, null);
+    }
+
+    @Override
+    public McpSchema.CallToolResult execute(Map<String, Object> arguments, Program currentProgram,
+                                            GhidrAssistMCPBackend backend, McpTask task) {
+        return executeInternal(arguments, currentProgram, backend, task);
+    }
+
+    private McpSchema.CallToolResult executeInternal(Map<String, Object> arguments, Program currentProgram,
+                                                    GhidrAssistMCPBackend backend, McpTask task) {
+        List<Program> programs = resolvePrograms(arguments, currentProgram, backend);
+        if (programs.isEmpty()) {
+            return textResult("No program currently loaded.");
+        }
+
+        String mode = (String) arguments.get("mode");
+        Map<String, Object> options = AnalysisUtils.objectMap(arguments.get("options"));
+        String startAddress = (String) arguments.get("start_address");
+        String endAddress = (String) arguments.get("end_address");
+
+        if (programs.size() > 1 &&
+            ((startAddress != null && !startAddress.isBlank()) || (endAddress != null && !endAddress.isBlank()))) {
+            return textResult("Address range analysis is only supported for a single target program.");
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("Auto Analysis Results\n\n");
+        int total = programs.size();
+        for (int i = 0; i < total; i++) {
+            Program program = programs.get(i);
+            TaskMonitor monitor = monitorForProgram(task, program, i, total);
+            try {
+                publishProgramProgress(task, program, i, total, "Preparing");
+                AddressSet range = AnalysisUtils.parseRange(program, startAddress, endAddress);
+                sb.append(AnalysisUtils.runAnalysis(program, mode, range, options, monitor));
+                sb.append("\n\n");
+                publishProgramProgress(task, program, i, total, "Completed");
+            } catch (Exception e) {
+                Msg.error(this, "Analysis failed for " + program.getName(), e);
+                sb.append("Analysis failed for ").append(program.getName()).append(": ")
+                  .append(e.getMessage()).append("\n\n");
+            }
+        }
+
+        if (backend != null) {
+            backend.clearCache();
+        }
+        return textResult(sb.toString().trim());
+    }
+
+    private TaskMonitor monitorForProgram(McpTask task, Program program, int index, int total) {
+        if (task == null) {
+            return TaskMonitor.DUMMY;
+        }
+        return new McpTaskMonitor(task, startPercent(index, total), endPercent(index, total),
+            "Analyzing " + program.getName() + " (" + (index + 1) + "/" + total + ")");
+    }
+
+    private void publishProgramProgress(McpTask task, Program program, int index, int total, String status) {
+        if (task == null) {
+            return;
+        }
+        int percent = "Completed".equals(status) ? endPercent(index, total) : startPercent(index, total);
+        task.updateProgress(percent, status + " " + program.getName() +
+            " (" + (index + 1) + "/" + total + ")");
+    }
+
+    private int startPercent(int index, int total) {
+        return (index * 99) / total;
+    }
+
+    private int endPercent(int index, int total) {
+        return ((index + 1) * 99) / total;
+    }
+
+    private List<Program> resolvePrograms(Map<String, Object> arguments, Program currentProgram,
+                                          GhidrAssistMCPBackend backend) {
+        String scope = (String) arguments.get("scope");
+        if ("all_open".equalsIgnoreCase(scope)) {
+            if (backend != null) {
+                return backend.getAllOpenPrograms();
+            }
+            return currentProgram != null ? List.of(currentProgram) : List.of();
+        }
+
+        List<Program> result = new ArrayList<>();
+        if (currentProgram != null) {
+            result.add(currentProgram);
+        }
+        return result;
+    }
+
+    private McpSchema.CallToolResult textResult(String message) {
+        return McpSchema.CallToolResult.builder()
+            .addTextContent(message)
+            .build();
+    }
+}

--- a/src/main/java/ghidrassistmcp/tools/CloseProgramTool.java
+++ b/src/main/java/ghidrassistmcp/tools/CloseProgramTool.java
@@ -1,0 +1,194 @@
+package ghidrassistmcp.tools;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import ghidra.app.services.ProgramManager;
+import ghidra.framework.model.DomainFile;
+import ghidra.framework.plugintool.PluginTool;
+import ghidra.program.model.listing.Program;
+import ghidra.util.Msg;
+import ghidrassistmcp.GhidrAssistMCPBackend;
+import ghidrassistmcp.GhidrAssistMCPManager;
+import ghidrassistmcp.McpTool;
+import io.modelcontextprotocol.spec.McpSchema;
+
+public class CloseProgramTool implements McpTool {
+
+    @Override
+    public String getName() {
+        return "close_program";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Close an open program in CodeBrowser. If name is omitted, closes the current program. " +
+            "Changed programs require save=true or ignore_changes=true.";
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        return false;
+    }
+
+    @Override
+    public boolean isIdempotent() {
+        return true;
+    }
+
+    @Override
+    public McpSchema.JsonSchema getInputSchema() {
+        return new McpSchema.JsonSchema("object",
+            Map.ofEntries(
+                Map.entry("name", Map.of(
+                    "type", "string",
+                    "description", "Open program name or project path to close. If omitted, closes the current program."
+                )),
+                Map.entry("save", Map.of(
+                    "type", "boolean",
+                    "description", "Save the program before closing if it has changes. Default: false.",
+                    "default", false
+                )),
+                Map.entry("ignore_changes", Map.of(
+                    "type", "boolean",
+                    "description", "Close without saving even if the program has changes. Default: false.",
+                    "default", false
+                ))
+            ),
+            List.of(), null, null, null);
+    }
+
+    @Override
+    public McpSchema.CallToolResult execute(Map<String, Object> arguments, Program currentProgram) {
+        return execute(arguments, currentProgram, null);
+    }
+
+    @Override
+    public McpSchema.CallToolResult execute(Map<String, Object> arguments, Program currentProgram,
+                                            GhidrAssistMCPBackend backend) {
+        GhidrAssistMCPManager manager = GhidrAssistMCPManager.getInstance();
+        PluginTool pluginTool = manager.getActiveTool();
+        if (pluginTool == null) {
+            return textResult("No active Ghidra tool/window available.");
+        }
+
+        ProgramManager programManager = pluginTool.getService(ProgramManager.class);
+        if (programManager == null) {
+            return textResult("ProgramManager service not available. Is CodeBrowser open?");
+        }
+
+        String name = stringArg(arguments.get("name"), null);
+        boolean save = Boolean.TRUE.equals(arguments.get("save"));
+        boolean ignoreChanges = Boolean.TRUE.equals(arguments.get("ignore_changes"));
+
+        Program target = name == null ? programManager.getCurrentProgram() :
+            resolveOpenProgram(programManager.getAllOpenPrograms(), name);
+        if (target == null) {
+            if (name == null) {
+                return textResult("No current program is open.");
+            }
+            return textResult("Open program not found: " + name);
+        }
+
+        String label = describeProgram(target);
+        boolean changedBefore = target.isChanged();
+        if (changedBefore && save) {
+            try {
+                programManager.saveProgram(target);
+            } catch (Exception e) {
+                Msg.error(this, "Failed to save program before close: " + label, e);
+                return textResult("Failed to save before closing " + label + ": " +
+                    e.getClass().getSimpleName() + ": " + e.getMessage());
+            }
+        }
+
+        boolean changedAfterSave = target.isChanged();
+        if (changedAfterSave && !ignoreChanges) {
+            return textResult("Refusing to close changed program without saving: " + label +
+                "\nPass save=true to save first, or ignore_changes=true to close without saving.");
+        }
+
+        boolean closed;
+        try {
+            closed = programManager.closeProgram(target, ignoreChanges);
+        } catch (Exception e) {
+            Msg.error(this, "Failed to close program: " + label, e);
+            return textResult("Failed to close " + label + ": " +
+                e.getClass().getSimpleName() + ": " + e.getMessage());
+        }
+
+        if (!closed) {
+            return textResult("Program was not closed: " + label);
+        }
+
+        if (backend != null) {
+            backend.clearCache();
+        }
+
+        return textResult("Closed program: " + label + "\n" +
+            "Changed Before Close: " + changedBefore + "\n" +
+            "Saved Before Close: " + (changedBefore && save) + "\n" +
+            "Ignored Unsaved Changes: " + (changedAfterSave && ignoreChanges) + "\n" +
+            "Open Programs Remaining: " + programManager.getAllOpenPrograms().length);
+    }
+
+    private Program resolveOpenProgram(Program[] openPrograms, String name) {
+        List<Program> exactMatches = new ArrayList<>();
+        List<Program> caseInsensitiveMatches = new ArrayList<>();
+        List<Program> partialMatches = new ArrayList<>();
+        String lowerName = name.toLowerCase();
+
+        for (Program program : openPrograms) {
+            String programName = program.getName();
+            String path = projectPath(program);
+            if (programName.equals(name) || name.equals(path)) {
+                exactMatches.add(program);
+            }
+            else if (programName.equalsIgnoreCase(name) || path.equalsIgnoreCase(name)) {
+                caseInsensitiveMatches.add(program);
+            }
+            else if (programName.toLowerCase().contains(lowerName) ||
+                     path.toLowerCase().contains(lowerName)) {
+                partialMatches.add(program);
+            }
+        }
+
+        if (exactMatches.size() == 1) {
+            return exactMatches.get(0);
+        }
+        if (caseInsensitiveMatches.size() == 1) {
+            return caseInsensitiveMatches.get(0);
+        }
+        if (partialMatches.size() == 1) {
+            return partialMatches.get(0);
+        }
+        return null;
+    }
+
+    private String describeProgram(Program program) {
+        String path = projectPath(program);
+        if (!path.isBlank()) {
+            return program.getName() + " (" + path + ")";
+        }
+        return program.getName();
+    }
+
+    private String projectPath(Program program) {
+        DomainFile domainFile = program.getDomainFile();
+        return domainFile != null ? domainFile.getPathname() : "";
+    }
+
+    private String stringArg(Object value, String defaultValue) {
+        if (value instanceof String text && !text.isBlank()) {
+            return text;
+        }
+        return defaultValue;
+    }
+
+    private McpSchema.CallToolResult textResult(String message) {
+        return McpSchema.CallToolResult.builder()
+            .addTextContent(message)
+            .build();
+    }
+}

--- a/src/main/java/ghidrassistmcp/tools/CreateFunctionTool.java
+++ b/src/main/java/ghidrassistmcp/tools/CreateFunctionTool.java
@@ -7,9 +7,13 @@ package ghidrassistmcp.tools;
 import java.util.List;
 import java.util.Map;
 
+import ghidra.app.cmd.disassemble.DisassembleCommand;
 import ghidra.app.cmd.function.CreateFunctionCmd;
 import ghidra.program.model.address.Address;
+import ghidra.program.model.address.AddressSet;
+import ghidra.program.model.listing.CodeUnit;
 import ghidra.program.model.listing.Function;
+import ghidra.program.model.listing.Listing;
 import ghidra.program.model.listing.Program;
 import ghidra.program.model.symbol.SourceType;
 import ghidrassistmcp.McpTool;
@@ -29,17 +33,26 @@ public class CreateFunctionTool implements McpTool {
     public String getDescription() {
         return "Create (define) a function at a specific address. "
              + "Ghidra will auto-detect the function body via flow analysis. "
-             + "Optionally provide a name for the function.";
+             + "Optionally clear existing code/data units first and provide a name for the function.";
     }
 
     @Override
     public McpSchema.JsonSchema getInputSchema() {
         return new McpSchema.JsonSchema("object",
-            Map.of(
-                "address", Map.of("type", "string",
-                    "description", "Entry point address for the function (e.g. '0xC121' or 'C121')"),
-                "name", Map.of("type", "string",
-                    "description", "Optional name for the function (default: auto-generated FUN_xxxx)")
+            Map.ofEntries(
+                Map.entry("address", Map.of("type", "string",
+                    "description", "Entry point address for the function (e.g. '0xC121' or 'C121')")),
+                Map.entry("name", Map.of("type", "string",
+                    "description", "Optional name for the function (default: auto-generated FUN_xxxx)")),
+                Map.entry("clear_existing", Map.of(
+                    "type", "boolean",
+                    "description", "Clear existing instructions/data before creating the function. Default: false.",
+                    "default", false)),
+                Map.entry("clear_length", Map.of(
+                    "type", "integer",
+                    "description", "When clear_existing=true, bytes to clear from the entry address. " +
+                        "If omitted, clears only the code/data unit containing the entry.",
+                    "minimum", 1))
             ),
             List.of("address"), null, null, null);
     }
@@ -53,6 +66,8 @@ public class CreateFunctionTool implements McpTool {
 
         String addressStr = (String) arguments.get("address");
         String name = (String) arguments.get("name");
+        boolean clearExisting = Boolean.TRUE.equals(arguments.get("clear_existing"));
+        int clearLength = numberArg(arguments.get("clear_length"), 0);
 
         Address entryPoint;
         try {
@@ -76,6 +91,18 @@ public class CreateFunctionTool implements McpTool {
                 .build();
         }
 
+        ClearResult clearResult = ClearResult.none();
+        if (clearExisting) {
+            try {
+                clearResult = clearExistingCodeUnits(currentProgram, entryPoint, clearLength);
+            } catch (Exception e) {
+                return McpSchema.CallToolResult.builder()
+                    .addTextContent("Failed to clear existing code/data units at " + addressStr +
+                        ": " + e.getMessage())
+                    .build();
+            }
+        }
+
         // Use CreateFunctionCmd which performs flow-based body detection
         CreateFunctionCmd cmd = new CreateFunctionCmd(entryPoint);
         boolean success = cmd.applyTo(currentProgram);
@@ -83,17 +110,29 @@ public class CreateFunctionTool implements McpTool {
         if (!success) {
             // Fallback: try to disassemble first, then create function
             int txId = currentProgram.startTransaction("Disassemble for function creation");
+            boolean txClosed = false;
             try {
-                ghidra.app.cmd.disassemble.DisassembleCommand disCmd =
-                    new ghidra.app.cmd.disassemble.DisassembleCommand(entryPoint, null, true);
-                disCmd.applyTo(currentProgram);
-                currentProgram.endTransaction(txId, true);
+                AddressSet disassembleRange =
+                    clearResult.endAddress() != null ? new AddressSet(entryPoint, clearResult.endAddress()) : null;
+                DisassembleCommand disCmd = new DisassembleCommand(entryPoint, disassembleRange, true);
+                boolean disassembled = disCmd.applyTo(currentProgram);
+                currentProgram.endTransaction(txId, disassembled);
+                txClosed = true;
+
+                if (!disassembled) {
+                    return McpSchema.CallToolResult.builder()
+                        .addTextContent("Failed to disassemble at " + addressStr +
+                            ". Try clear_existing=true with an explicit clear_length if the region is data.")
+                        .build();
+                }
 
                 // Retry function creation after disassembly
                 cmd = new CreateFunctionCmd(entryPoint);
                 success = cmd.applyTo(currentProgram);
             } catch (Exception e) {
-                currentProgram.endTransaction(txId, false);
+                if (!txClosed) {
+                    currentProgram.endTransaction(txId, false);
+                }
                 return McpSchema.CallToolResult.builder()
                     .addTextContent("Failed to disassemble at " + addressStr + ": " + e.getMessage())
                     .build();
@@ -136,9 +175,57 @@ public class CreateFunctionTool implements McpTool {
         sb.append("  Entry: ").append(func.getEntryPoint()).append("\n");
         sb.append("  Body size: ").append(func.getBody().getNumAddresses()).append(" bytes\n");
         sb.append("  Range: ").append(func.getBody().getMinAddress())
-          .append(" - ").append(func.getBody().getMaxAddress());
+          .append(" - ").append(func.getBody().getMaxAddress()).append("\n");
+        sb.append("  Cleared existing code/data units: ").append(clearResult.description());
 
         return McpSchema.CallToolResult.builder()
             .addTextContent(sb.toString()).build();
+    }
+
+    @Override
+    public boolean isDestructive() { return true; }
+
+    private ClearResult clearExistingCodeUnits(Program program, Address entryPoint, int clearLength)
+            throws Exception {
+        Listing listing = program.getListing();
+        Address clearStart = entryPoint;
+        Address clearEnd;
+
+        if (clearLength > 0) {
+            clearEnd = entryPoint.add(clearLength - 1);
+        } else {
+            CodeUnit codeUnit = listing.getCodeUnitContaining(entryPoint);
+            if (codeUnit != null) {
+                clearStart = codeUnit.getMinAddress();
+                clearEnd = codeUnit.getMaxAddress();
+            } else {
+                clearEnd = entryPoint;
+            }
+        }
+
+        int txId = program.startTransaction("Clear existing code/data before function creation");
+        boolean committed = false;
+        try {
+            listing.clearCodeUnits(clearStart, clearEnd, false);
+            committed = true;
+        } finally {
+            program.endTransaction(txId, committed);
+        }
+
+        String description = clearStart + " - " + clearEnd;
+        return new ClearResult(clearEnd, description);
+    }
+
+    private int numberArg(Object value, int defaultValue) {
+        if (value instanceof Number number) {
+            return number.intValue();
+        }
+        return defaultValue;
+    }
+
+    private record ClearResult(Address endAddress, String description) {
+        static ClearResult none() {
+            return new ClearResult(null, "false");
+        }
     }
 }

--- a/src/main/java/ghidrassistmcp/tools/DisassembleAtTool.java
+++ b/src/main/java/ghidrassistmcp/tools/DisassembleAtTool.java
@@ -30,17 +30,22 @@ public class DisassembleAtTool implements McpTool {
     @Override
     public String getDescription() {
         return "Disassemble code at a specific address, even if no function is defined. "
-             + "Converts undefined bytes into instructions and returns the disassembly listing.";
+             + "Converts undefined bytes into instructions and can optionally clear existing "
+             + "code/data units first.";
     }
 
     @Override
     public McpSchema.JsonSchema getInputSchema() {
         return new McpSchema.JsonSchema("object",
-            Map.of(
-                "address", Map.of("type", "string",
-                    "description", "Start address to disassemble (e.g. '0xC121' or 'C121')"),
-                "length", Map.of("type", "integer",
-                    "description", "Maximum number of bytes to disassemble (default: 128)")
+            Map.ofEntries(
+                Map.entry("address", Map.of("type", "string",
+                    "description", "Start address to disassemble (e.g. '0xC121' or 'C121')")),
+                Map.entry("length", Map.of("type", "integer",
+                    "description", "Number of bytes to disassemble or clear (default: 128)")),
+                Map.entry("clear_existing", Map.of(
+                    "type", "boolean",
+                    "description", "Clear existing instructions/data in the range before disassembly. Default: false.",
+                    "default", false))
             ),
             List.of("address"), null, null, null);
     }
@@ -62,6 +67,7 @@ public class DisassembleAtTool implements McpTool {
         // Cap at a reasonable maximum
         if (length > 4096) length = 4096;
         if (length < 1) length = 128;
+        boolean clearExisting = Boolean.TRUE.equals(arguments.get("clear_existing"));
 
         Address startAddr;
         try {
@@ -82,8 +88,18 @@ public class DisassembleAtTool implements McpTool {
         // Disassemble the region (this is a write operation - converts bytes to instructions)
         int txId = currentProgram.startTransaction("Disassemble at " + addressStr);
         try {
+            if (clearExisting) {
+                currentProgram.getListing().clearCodeUnits(startAddr, endAddr, false);
+            }
             DisassembleCommand cmd = new DisassembleCommand(startAddr, range, true);
-            cmd.applyTo(currentProgram);
+            boolean success = cmd.applyTo(currentProgram);
+            if (!success) {
+                currentProgram.endTransaction(txId, false);
+                return McpSchema.CallToolResult.builder()
+                    .addTextContent("Disassembly failed at " + addressStr +
+                        ". Try clear_existing=true if the range is currently defined as data.")
+                    .build();
+            }
             currentProgram.endTransaction(txId, true);
         } catch (Exception e) {
             currentProgram.endTransaction(txId, false);
@@ -96,6 +112,7 @@ public class DisassembleAtTool implements McpTool {
         Listing listing = currentProgram.getListing();
         StringBuilder sb = new StringBuilder();
         sb.append("Disassembly at ").append(startAddr).append(":\n\n");
+        sb.append("Cleared existing code/data units: ").append(clearExisting).append("\n\n");
 
         int instrCount = 0;
         InstructionIterator iter = listing.getInstructions(startAddr, true);
@@ -118,4 +135,7 @@ public class DisassembleAtTool implements McpTool {
         return McpSchema.CallToolResult.builder()
             .addTextContent(sb.toString()).build();
     }
+
+    @Override
+    public boolean isDestructive() { return true; }
 }

--- a/src/main/java/ghidrassistmcp/tools/GhidraScriptsTool.java
+++ b/src/main/java/ghidrassistmcp/tools/GhidraScriptsTool.java
@@ -1,0 +1,456 @@
+package ghidrassistmcp.tools;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+import generic.jar.ResourceFile;
+import ghidra.app.script.GhidraScript;
+import ghidra.app.script.GhidraScriptProvider;
+import ghidra.app.script.GhidraScriptUtil;
+import ghidra.app.script.GhidraState;
+import ghidra.app.script.ScriptInfo;
+import ghidra.framework.model.Project;
+import ghidra.framework.plugintool.PluginTool;
+import ghidra.program.model.address.Address;
+import ghidra.program.model.listing.Program;
+import ghidra.program.util.ProgramLocation;
+import ghidra.util.Msg;
+import ghidra.util.task.TaskMonitor;
+import ghidrassistmcp.GhidrAssistMCPBackend;
+import ghidrassistmcp.GhidrAssistMCPManager;
+import ghidrassistmcp.McpTool;
+import ghidrassistmcp.tasks.McpTask;
+import io.modelcontextprotocol.spec.McpSchema;
+
+public class GhidraScriptsTool implements McpTool {
+
+    @Override
+    public String getName() {
+        return "scripts";
+    }
+
+    @Override
+    public String getDescription() {
+        return "List, read, create, delete, and run Ghidra scripts. " +
+            "Create/delete are restricted to the user script directory; run uses Ghidra's script providers.";
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        return false;
+    }
+
+    @Override
+    public boolean isDestructive() {
+        return true;
+    }
+
+    @Override
+    public boolean isOpenWorld() {
+        return true;
+    }
+
+    @Override
+    public McpSchema.JsonSchema getInputSchema() {
+        return new McpSchema.JsonSchema("object",
+            Map.ofEntries(
+                Map.entry("action", Map.of(
+                    "type", "string",
+                    "description", "Operation to perform",
+                    "enum", List.of("list", "get", "create", "delete", "run")
+                )),
+                Map.entry("name", Map.of(
+                    "type", "string",
+                    "description", "Script file name or relative path, e.g. 'MyScript.java'"
+                )),
+                Map.entry("source", Map.of(
+                    "type", "string",
+                    "description", "For action='create': script source text. If omitted, provider template is used."
+                )),
+                Map.entry("overwrite", Map.of(
+                    "type", "boolean",
+                    "description", "For action='create': overwrite an existing user script. Default: false",
+                    "default", false
+                )),
+                Map.entry("confirm", Map.of(
+                    "type", "boolean",
+                    "description", "Required true for action='delete'"
+                )),
+                Map.entry("filter", Map.of(
+                    "type", "string",
+                    "description", "For action='list': case-insensitive substring filter"
+                )),
+                Map.entry("user_only", Map.of(
+                    "type", "boolean",
+                    "description", "For action='list': only list scripts in the user script directory. Default: false",
+                    "default", false
+                )),
+                Map.entry("offset", Map.of(
+                    "type", "integer",
+                    "description", "For action='list': number of matching scripts to skip. Default: 0",
+                    "default", 0,
+                    "minimum", 0
+                )),
+                Map.entry("limit", Map.of(
+                    "type", "integer",
+                    "description", "For action='list': maximum scripts to return. Default: 200",
+                    "default", 200,
+                    "minimum", 1
+                )),
+                Map.entry("max_bytes", Map.of(
+                    "type", "integer",
+                    "description", "For action='get': maximum source bytes to return. Default: 65536",
+                    "default", 65536,
+                    "minimum", 1
+                )),
+                Map.entry("args", Map.of(
+                    "type", "array",
+                    "description", "For action='run': script arguments",
+                    "items", Map.of("type", "string")
+                ))
+            ),
+            List.of("action"), null, null, null);
+    }
+
+    @Override
+    public McpSchema.CallToolResult execute(Map<String, Object> arguments, Program currentProgram) {
+        return execute(arguments, currentProgram, null);
+    }
+
+    @Override
+    public McpSchema.CallToolResult execute(Map<String, Object> arguments, Program currentProgram,
+                                            GhidrAssistMCPBackend backend) {
+        String action = stringArg(arguments.get("action"), null);
+        if (action == null) {
+            return textResult("action is required: list, get, create, delete, or run.");
+        }
+
+        try {
+            return switch (action.trim().toLowerCase()) {
+                case "list" -> listScripts(arguments);
+                case "get" -> getScript(arguments);
+                case "create" -> createScript(arguments);
+                case "delete" -> deleteScript(arguments);
+                case "run" -> submitRun(arguments, currentProgram, backend);
+                default -> textResult("Invalid action: " + action + ". Use list, get, create, delete, or run.");
+            };
+        } catch (Exception e) {
+            Msg.error(this, "scripts tool failed", e);
+            return textResult("scripts " + action + " failed: " +
+                e.getClass().getSimpleName() + ": " + e.getMessage());
+        }
+    }
+
+    private McpSchema.CallToolResult listScripts(Map<String, Object> arguments) {
+        String filter = stringArg(arguments.get("filter"), null);
+        String normalizedFilter = filter != null ? filter.toLowerCase() : null;
+        boolean userOnly = Boolean.TRUE.equals(arguments.get("user_only"));
+        int offset = numberArg(arguments.get("offset"), 0);
+        int limit = numberArg(arguments.get("limit"), 200);
+
+        ResourceFile userDir = getUserScriptDirectory();
+        List<ResourceFile> roots = userOnly ? List.of(userDir) :
+            GhidraScriptUtil.getEnabledScriptSourceDirectories();
+
+        List<ScriptRow> rows = new ArrayList<>();
+        for (ResourceFile root : roots) {
+            collectScripts(root, userDir, normalizedFilter, rows);
+        }
+        rows.sort(Comparator.comparing(row -> row.name, String.CASE_INSENSITIVE_ORDER));
+
+        int end = Math.min(rows.size(), offset + limit);
+        StringBuilder sb = new StringBuilder();
+        sb.append("Ghidra Scripts\n\n");
+        for (int i = offset; i < end; i++) {
+            ScriptRow row = rows.get(i);
+            sb.append("- ").append(row.name).append("\n");
+            sb.append("  Runtime: ").append(row.runtime).append("\n");
+            sb.append("  Scope: ").append(row.userScript ? "user" : "system").append("\n");
+            sb.append("  Path: ").append(row.path).append("\n");
+            if (!row.category.isBlank()) {
+                sb.append("  Category: ").append(row.category).append("\n");
+            }
+            if (!row.description.isBlank()) {
+                sb.append("  Description: ").append(row.description).append("\n");
+            }
+        }
+        sb.append("\nShowing ").append(Math.max(0, end - offset))
+          .append(" of ").append(rows.size()).append(" matching script(s)");
+        if (offset > 0) {
+            sb.append(" (offset ").append(offset).append(")");
+        }
+        sb.append("\nUser script directory: ").append(userDir.getAbsolutePath());
+        return textResult(sb.toString());
+    }
+
+    private McpSchema.CallToolResult getScript(Map<String, Object> arguments) throws IOException {
+        String name = requiredName(arguments);
+        ResourceFile script = resolveExistingScript(name, true);
+        int maxBytes = numberArg(arguments.get("max_bytes"), 65536);
+        if (maxBytes < 1) {
+            maxBytes = 65536;
+        }
+
+        byte[] bytes;
+        boolean truncated;
+        try (InputStream input = script.getInputStream()) {
+            bytes = readUpTo(input, maxBytes + 1);
+            truncated = bytes.length > maxBytes;
+        }
+        if (truncated) {
+            byte[] trimmed = new byte[maxBytes];
+            System.arraycopy(bytes, 0, trimmed, 0, maxBytes);
+            bytes = trimmed;
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("Script: ").append(script.getName()).append("\n");
+        sb.append("Path: ").append(script.getAbsolutePath()).append("\n");
+        sb.append("Provider: ").append(providerName(script)).append("\n");
+        sb.append("Truncated: ").append(truncated).append("\n\n");
+        sb.append(new String(bytes, StandardCharsets.UTF_8));
+        return textResult(sb.toString());
+    }
+
+    private McpSchema.CallToolResult createScript(Map<String, Object> arguments) throws IOException {
+        String name = requiredName(arguments);
+        ResourceFile script = resolveUserScriptPath(name, true);
+        GhidraScriptProvider provider = GhidraScriptUtil.getProvider(script);
+        if (provider == null) {
+            return textResult("No Ghidra script provider for: " + script.getName());
+        }
+
+        File file = script.getFile(false);
+        if (file.exists() && !Boolean.TRUE.equals(arguments.get("overwrite"))) {
+            return textResult("User script already exists: " + file.getAbsolutePath() +
+                "\nPass overwrite=true to replace it.");
+        }
+
+        Files.createDirectories(file.toPath().getParent());
+        String source = stringArg(arguments.get("source"), null);
+        if (source != null) {
+            Files.writeString(file.toPath(), source, StandardCharsets.UTF_8);
+        } else {
+            provider.createNewScript(script, "");
+        }
+
+        return textResult("Created user script: " + file.getAbsolutePath() +
+            "\nProvider: " + provider.getDescription());
+    }
+
+    private McpSchema.CallToolResult deleteScript(Map<String, Object> arguments) throws IOException {
+        if (!Boolean.TRUE.equals(arguments.get("confirm"))) {
+            return textResult("Refusing to delete. Pass confirm=true to delete a user script.");
+        }
+
+        String name = requiredName(arguments);
+        ResourceFile script = resolveUserScriptPath(name, false);
+        if (!script.exists() || !script.isFile()) {
+            return textResult("User script not found: " + script.getAbsolutePath());
+        }
+
+        GhidraScriptProvider provider = GhidraScriptUtil.getProvider(script);
+        boolean deleted = provider != null ? provider.deleteScript(script) : script.delete();
+        if (!deleted && script.exists()) {
+            return textResult("Failed to delete user script: " + script.getAbsolutePath());
+        }
+        return textResult("Deleted user script: " + script.getAbsolutePath());
+    }
+
+    private McpSchema.CallToolResult submitRun(Map<String, Object> arguments, Program currentProgram,
+                                               GhidrAssistMCPBackend backend) {
+        if (backend != null && backend.getTaskManager() != null) {
+            McpTask task = backend.getTaskManager().submitTask(
+                getName(), arguments, () -> runScript(arguments, currentProgram, backend));
+            return textResult("Script task submitted: " + task.getTaskId() +
+                "\nUse get_task_status with this task_id to retrieve the result.");
+        }
+        return runScript(arguments, currentProgram, backend);
+    }
+
+    private McpSchema.CallToolResult runScript(Map<String, Object> arguments, Program currentProgram,
+                                               GhidrAssistMCPBackend backend) {
+        StringWriter output = new StringWriter();
+        PrintWriter writer = new PrintWriter(output, true);
+
+        try {
+            String name = requiredName(arguments);
+            ResourceFile scriptFile = resolveExistingScript(name, true);
+            GhidraScriptProvider provider = GhidraScriptUtil.getProvider(scriptFile);
+            if (provider == null) {
+                return textResult("No Ghidra script provider for: " + scriptFile.getName());
+            }
+
+            GhidraScript script = provider.getScriptInstance(scriptFile, writer);
+            script.setSourceFile(scriptFile);
+            List<String> args = AnalysisUtils.stringList(arguments.get("args"));
+            if (args != null) {
+                script.setScriptArgs(args.toArray(String[]::new));
+            }
+
+            GhidraState state = buildState(currentProgram, backend);
+            script.execute(state, TaskMonitor.DUMMY, writer);
+
+            if (backend != null) {
+                backend.clearCache();
+            }
+
+            StringBuilder sb = new StringBuilder();
+            sb.append("Script completed: ").append(scriptFile.getName()).append("\n");
+            sb.append("Provider: ").append(provider.getDescription()).append("\n\n");
+            sb.append(output);
+            return textResult(sb.toString().trim());
+        } catch (Exception e) {
+            Msg.error(this, "Failed to run script", e);
+            return textResult("Script failed: " + e.getClass().getSimpleName() + ": " +
+                e.getMessage() + "\n\nOutput before failure:\n" + output);
+        }
+    }
+
+    private GhidraState buildState(Program currentProgram, GhidrAssistMCPBackend backend) {
+        GhidrAssistMCPManager manager = GhidrAssistMCPManager.getInstance();
+        PluginTool tool = manager.getActiveTool();
+        Project project = tool != null ? tool.getProject() : null;
+        Address currentAddress = null;
+        if (backend != null && backend.getActivePlugin() != null) {
+            currentAddress = backend.getActivePlugin().getCurrentAddress();
+        }
+        ProgramLocation location =
+            currentProgram != null && currentAddress != null ? new ProgramLocation(currentProgram, currentAddress) : null;
+        return new GhidraState(tool, project, currentProgram, location, null, null);
+    }
+
+    private void collectScripts(ResourceFile root, ResourceFile userDir, String filter, List<ScriptRow> rows) {
+        ResourceFile[] children = root.listFiles();
+        if (children == null) {
+            return;
+        }
+        for (ResourceFile child : children) {
+            if (child.isDirectory()) {
+                collectScripts(child, userDir, filter, rows);
+                continue;
+            }
+            if (!GhidraScriptUtil.hasScriptProvider(child)) {
+                continue;
+            }
+            if (filter != null && !child.getName().toLowerCase().contains(filter)) {
+                continue;
+            }
+            ScriptInfo info = GhidraScriptUtil.newScriptInfo(child);
+            rows.add(new ScriptRow(
+                info.getName(),
+                info.getRuntimeEnvironmentName(),
+                String.join("/", info.getCategory()),
+                nullToEmpty(info.getDescription()),
+                child.getAbsolutePath(),
+                userDir.containsPath(child)));
+        }
+    }
+
+    private ResourceFile resolveExistingScript(String name, boolean allowSystem) throws IOException {
+        ResourceFile userScript = resolveUserScriptPath(name, false);
+        if (userScript.exists() && userScript.isFile()) {
+            return userScript;
+        }
+        if (allowSystem) {
+            ResourceFile found = GhidraScriptUtil.findScriptByName(name);
+            if (found != null) {
+                return found;
+            }
+        }
+        throw new IOException("Script not found: " + name);
+    }
+
+    private ResourceFile resolveUserScriptPath(String name, boolean defaultJavaExtension) throws IOException {
+        String normalizedName = name.trim().replace('\\', '/');
+        if (normalizedName.isBlank() || normalizedName.startsWith("/") || normalizedName.contains(":")) {
+            throw new IOException("Script name must be a relative path inside the user script directory.");
+        }
+        if (defaultJavaExtension && !normalizedName.contains(".")) {
+            normalizedName += ".java";
+        }
+
+        ResourceFile userDir = getUserScriptDirectory();
+        Path root = userDir.getFile(false).toPath().toAbsolutePath().normalize();
+        Path target = root.resolve(normalizedName).normalize();
+        if (!target.startsWith(root)) {
+            throw new IOException("Script path escapes the user script directory: " + name);
+        }
+        return new ResourceFile(target.toFile());
+    }
+
+    private ResourceFile getUserScriptDirectory() {
+        ResourceFile userDir = GhidraScriptUtil.getUserScriptDirectory();
+        if (!userDir.exists()) {
+            userDir.mkdir();
+        }
+        return userDir;
+    }
+
+    private String providerName(ResourceFile script) {
+        GhidraScriptProvider provider = GhidraScriptUtil.getProvider(script);
+        return provider != null ? provider.getDescription() : "unknown";
+    }
+
+    private byte[] readUpTo(InputStream input, int maxBytes) throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        byte[] buffer = new byte[8192];
+        int remaining = maxBytes;
+        while (remaining > 0) {
+            int read = input.read(buffer, 0, Math.min(buffer.length, remaining));
+            if (read < 0) {
+                break;
+            }
+            output.write(buffer, 0, read);
+            remaining -= read;
+        }
+        return output.toByteArray();
+    }
+
+    private String requiredName(Map<String, Object> arguments) {
+        String name = stringArg(arguments.get("name"), null);
+        if (name == null) {
+            throw new IllegalArgumentException("name is required.");
+        }
+        return name;
+    }
+
+    private String stringArg(Object value, String defaultValue) {
+        if (value instanceof String text && !text.isBlank()) {
+            return text;
+        }
+        return defaultValue;
+    }
+
+    private int numberArg(Object value, int defaultValue) {
+        if (value instanceof Number number) {
+            return Math.max(0, number.intValue());
+        }
+        return defaultValue;
+    }
+
+    private String nullToEmpty(String value) {
+        return value != null ? value : "";
+    }
+
+    private McpSchema.CallToolResult textResult(String message) {
+        return McpSchema.CallToolResult.builder()
+            .addTextContent(message)
+            .build();
+    }
+
+    private record ScriptRow(String name, String runtime, String category, String description,
+                             String path, boolean userScript) {
+    }
+}

--- a/src/main/java/ghidrassistmcp/tools/ImportFileTool.java
+++ b/src/main/java/ghidrassistmcp/tools/ImportFileTool.java
@@ -98,7 +98,11 @@ public class ImportFileTool implements McpTool {
                     "description", "Destination folder in the Ghidra project (e.g. '/' or '/banks'). Default: '/'.")),
                 Map.entry("open_after_import", Map.of(
                     "type", "boolean",
-                    "description", "Open the imported program in CodeBrowser after import. Default: true."))
+                    "description", "Open the imported program in CodeBrowser after import. Default: true.")),
+                Map.entry("suppress_analysis_prompt", Map.of(
+                    "type", "boolean",
+                    "description", "If open_after_import is true, set 'Should Ask To Analyze' to false before opening. Default: true.",
+                    "default", true))
             ),
             List.of("file_path"), null, null, null);
     }
@@ -159,6 +163,8 @@ public class ImportFileTool implements McpTool {
 
         Object openAfterObj = arguments.get("open_after_import");
         boolean openAfterImport = (openAfterObj == null) || Boolean.TRUE.equals(openAfterObj);
+        Object suppressPromptObj = arguments.get("suppress_analysis_prompt");
+        boolean suppressAnalysisPrompt = (suppressPromptObj == null) || Boolean.TRUE.equals(suppressPromptObj);
 
         // --- Perform import ---
         MessageLog messageLog = new MessageLog();
@@ -166,10 +172,11 @@ public class ImportFileTool implements McpTool {
         try {
             if (languageStr != null && !languageStr.isBlank()) {
                 return importWithLanguage(file, project, folderPath, languageStr, compilerStr,
-                    baseAddrStr, programName, openAfterImport, messageLog, pluginTool);
+                    baseAddrStr, programName, openAfterImport, suppressAnalysisPrompt,
+                    messageLog, pluginTool);
             } else {
                 return importAutoDetect(file, project, folderPath, baseAddrStr, programName,
-                    openAfterImport, messageLog, pluginTool);
+                    openAfterImport, suppressAnalysisPrompt, messageLog, pluginTool);
             }
         } catch (ghidra.util.exception.DuplicateNameException e) {
             return textResult("A program with that name already exists in folder '" + folderPath +
@@ -182,7 +189,8 @@ public class ImportFileTool implements McpTool {
 
     private McpSchema.CallToolResult importWithLanguage(File file, Project project, String folderPath,
             String languageStr, String compilerStr, String baseAddrStr, String programName,
-            boolean openAfterImport, MessageLog messageLog, PluginTool pluginTool) throws Exception {
+            boolean openAfterImport, boolean suppressAnalysisPrompt, MessageLog messageLog,
+            PluginTool pluginTool) throws Exception {
 
         Language language;
         try {
@@ -228,7 +236,7 @@ public class ImportFileTool implements McpTool {
             StringBuilder result = buildResultMessage(importedProgram, folderPath, messageLog);
 
             if (openAfterImport) {
-                result.append(openInCodeBrowser(pluginTool, importedProgram));
+                result.append(openInCodeBrowser(pluginTool, importedProgram, suppressAnalysisPrompt));
             }
 
             return McpSchema.CallToolResult.builder()
@@ -239,7 +247,7 @@ public class ImportFileTool implements McpTool {
 
     private McpSchema.CallToolResult importAutoDetect(File file, Project project, String folderPath,
             String baseAddrStr, String programName, boolean openAfterImport,
-            MessageLog messageLog, PluginTool pluginTool) throws Exception {
+            boolean suppressAnalysisPrompt, MessageLog messageLog, PluginTool pluginTool) throws Exception {
 
         ProgramLoader.Builder loader = ProgramLoader.builder()
             .source(file)
@@ -265,7 +273,7 @@ public class ImportFileTool implements McpTool {
             StringBuilder result = buildResultMessage(importedProgram, folderPath, messageLog);
 
             if (openAfterImport) {
-                result.append(openInCodeBrowser(pluginTool, importedProgram));
+                result.append(openInCodeBrowser(pluginTool, importedProgram, suppressAnalysisPrompt));
             }
 
             return McpSchema.CallToolResult.builder()
@@ -300,11 +308,16 @@ public class ImportFileTool implements McpTool {
         }
     }
 
-    private static String openInCodeBrowser(PluginTool pluginTool, Program program) {
+    private static String openInCodeBrowser(PluginTool pluginTool, Program program,
+                                            boolean suppressAnalysisPrompt) {
         ProgramManager pm = pluginTool.getService(ProgramManager.class);
         if (pm != null) {
+            if (suppressAnalysisPrompt) {
+                AnalysisUtils.setAskToAnalyze(program, false);
+            }
             pm.openProgram(program);
-            return "  Opened in CodeBrowser: yes\n";
+            return "  Opened in CodeBrowser: yes\n" +
+                   "  Should Ask To Analyze: " + AnalysisUtils.shouldAskToAnalyze(program) + "\n";
         }
         return "  Opened in CodeBrowser: no (ProgramManager not available)\n";
     }

--- a/src/main/java/ghidrassistmcp/tools/OpenProgramTool.java
+++ b/src/main/java/ghidrassistmcp/tools/OpenProgramTool.java
@@ -4,6 +4,7 @@
 package ghidrassistmcp.tools;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -18,6 +19,7 @@ import ghidra.util.task.TaskMonitor;
 import ghidrassistmcp.GhidrAssistMCPBackend;
 import ghidrassistmcp.GhidrAssistMCPManager;
 import ghidrassistmcp.McpTool;
+import ghidrassistmcp.tasks.McpTask;
 import io.modelcontextprotocol.spec.McpSchema;
 
 /**
@@ -52,20 +54,40 @@ public class OpenProgramTool implements McpTool {
     @Override
     public McpSchema.JsonSchema getInputSchema() {
         return new McpSchema.JsonSchema("object",
-            Map.of(
-                "action", Map.of(
+            Map.ofEntries(
+                Map.entry("action", Map.of(
                     "type", "string",
                     "description", "Operation to perform",
                     "enum", List.of("list", "open")
-                ),
-                "name", Map.of(
+                )),
+                Map.entry("name", Map.of(
                     "type", "string",
                     "description", "Program name to open (required for action 'open'). Supports partial matching."
-                ),
-                "folder", Map.of(
+                )),
+                Map.entry("folder", Map.of(
                     "type", "string",
                     "description", "Project folder to search in (e.g. '/' or '/banks'). Default: search all folders."
-                )
+                )),
+                Map.entry("suppress_analysis_prompt", Map.of(
+                    "type", "boolean",
+                    "description", "For action 'open': set 'Should Ask To Analyze' to false before opening. Default: true.",
+                    "default", true
+                )),
+                Map.entry("analyze_after_open", Map.of(
+                    "type", "boolean",
+                    "description", "For action 'open': submit an analyze_program task after opening. Default: false.",
+                    "default", false
+                )),
+                Map.entry("analysis_mode", Map.of(
+                    "type", "string",
+                    "description", "For analyze_after_open: analysis mode",
+                    "enum", List.of("full", "changes"),
+                    "default", "full"
+                )),
+                Map.entry("analysis_options", Map.of(
+                    "type", "object",
+                    "description", "For analyze_after_open: optional analysis option overrides"
+                ))
             ),
             List.of("action"), null, null, null);
     }
@@ -150,7 +172,10 @@ public class OpenProgramTool implements McpTool {
         List<Program> openPrograms = backend.getAllOpenPrograms();
         for (Program p : openPrograms) {
             if (p.getName().equalsIgnoreCase(name)) {
-                return textResult("Program '" + p.getName() + "' is already open in CodeBrowser.");
+                StringBuilder sb = new StringBuilder();
+                sb.append("Program '").append(p.getName()).append("' is already open in CodeBrowser.\n");
+                sb.append(maybeSubmitAnalysis(p, arguments, backend));
+                return textResult(sb.toString().trim());
             }
         }
 
@@ -171,19 +196,70 @@ public class OpenProgramTool implements McpTool {
             return textResult("ProgramManager service not available. Is CodeBrowser open?");
         }
 
+        Program program = null;
         try {
-            Program program = (Program) match.getDomainObject(
+            program = (Program) match.getDomainObject(
                 this, false, false, TaskMonitor.DUMMY);
-            pm.openProgram(program);
-            program.release(this);
 
-            return textResult("Opened '" + match.getName() + "' (" + match.getPathname() +
-                ") in CodeBrowser.\nLanguage: " + program.getLanguageID() +
-                "\nImage Base: " + program.getImageBase());
+            if (getBoolean(arguments, "suppress_analysis_prompt", true)) {
+                AnalysisUtils.setAskToAnalyze(program, false);
+            }
+
+            pm.openProgram(program);
+
+            StringBuilder sb = new StringBuilder();
+            sb.append("Opened '").append(match.getName()).append("' (").append(match.getPathname())
+              .append(") in CodeBrowser.\n");
+            sb.append("Language: ").append(program.getLanguageID()).append("\n");
+            sb.append("Image Base: ").append(program.getImageBase()).append("\n");
+            sb.append("Should Ask To Analyze: ").append(AnalysisUtils.shouldAskToAnalyze(program)).append("\n");
+            sb.append(maybeSubmitAnalysis(program, arguments, backend));
+            return textResult(sb.toString().trim());
         } catch (Exception e) {
             Msg.error(this, "Failed to open program: " + match.getName(), e);
             return textResult("Failed to open '" + match.getName() + "': " + e.getMessage());
+        } finally {
+            if (program != null) {
+                program.release(this);
+            }
         }
+    }
+
+    private String maybeSubmitAnalysis(Program program, Map<String, Object> arguments,
+                                       GhidrAssistMCPBackend backend) {
+        if (!getBoolean(arguments, "analyze_after_open", false)) {
+            return "";
+        }
+        if (backend == null || backend.getTaskManager() == null) {
+            return "Analysis not submitted: task manager unavailable.\n";
+        }
+
+        Map<String, Object> taskArgs = new HashMap<>();
+        taskArgs.put("scope", "current");
+        Object mode = arguments.get("analysis_mode");
+        if (mode != null) {
+            taskArgs.put("mode", mode);
+        }
+        Object options = arguments.get("analysis_options");
+        if (options != null) {
+            taskArgs.put("options", options);
+        }
+
+        AnalyzeProgramTool analyzeTool = new AnalyzeProgramTool();
+        McpTask task = backend.getTaskManager().submitTask(
+            analyzeTool.getName(), taskArgs,
+            taskContext -> analyzeTool.execute(taskArgs, program, backend, taskContext));
+
+        return "Analysis task submitted: " + task.getTaskId() +
+            "\nUse get_task_status with this task_id to retrieve the result.\n";
+    }
+
+    private boolean getBoolean(Map<String, Object> arguments, String name, boolean defaultValue) {
+        Object value = arguments.get(name);
+        if (value instanceof Boolean bool) {
+            return bool;
+        }
+        return defaultValue;
     }
 
     /**

--- a/src/main/java/ghidrassistmcp/tools/ProjectFilesTool.java
+++ b/src/main/java/ghidrassistmcp/tools/ProjectFilesTool.java
@@ -1,0 +1,283 @@
+package ghidrassistmcp.tools;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+import ghidra.framework.model.DomainFile;
+import ghidra.framework.model.DomainFolder;
+import ghidra.framework.model.Project;
+import ghidra.framework.plugintool.PluginTool;
+import ghidra.util.Msg;
+import ghidrassistmcp.GhidrAssistMCPBackend;
+import ghidrassistmcp.GhidrAssistMCPManager;
+import ghidrassistmcp.McpTool;
+import io.modelcontextprotocol.spec.McpSchema;
+
+public class ProjectFilesTool implements McpTool {
+
+    @Override
+    public String getName() {
+        return "project_files";
+    }
+
+    @Override
+    public String getDescription() {
+        return "List or delete files/folders in the active Ghidra project. " +
+            "Deletion requires confirm=true and removes Ghidra project database entries, not original imported files.";
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        return false;
+    }
+
+    @Override
+    public boolean isDestructive() {
+        return true;
+    }
+
+    @Override
+    public boolean isIdempotent() {
+        return false;
+    }
+
+    @Override
+    public McpSchema.JsonSchema getInputSchema() {
+        return new McpSchema.JsonSchema("object",
+            Map.ofEntries(
+                Map.entry("action", Map.of(
+                    "type", "string",
+                    "description", "Operation to perform",
+                    "enum", List.of("list", "delete")
+                )),
+                Map.entry("path", Map.of(
+                    "type", "string",
+                    "description", "Project path for action='delete' (e.g. '/banks/bank00.bin' or '/banks')"
+                )),
+                Map.entry("folder", Map.of(
+                    "type", "string",
+                    "description", "Project folder to list. Default: '/'"
+                )),
+                Map.entry("target_type", Map.of(
+                    "type", "string",
+                    "description", "For delete: file, folder, or auto. Default: auto",
+                    "enum", List.of("auto", "file", "folder"),
+                    "default", "auto"
+                )),
+                Map.entry("recursive", Map.of(
+                    "type", "boolean",
+                    "description", "For list/delete folder: include/delete children recursively. Default: false",
+                    "default", false
+                )),
+                Map.entry("confirm", Map.of(
+                    "type", "boolean",
+                    "description", "Required true for action='delete'"
+                ))
+            ),
+            List.of("action"), null, null, null);
+    }
+
+    @Override
+    public McpSchema.CallToolResult execute(Map<String, Object> arguments, ghidra.program.model.listing.Program currentProgram) {
+        return textResult("This tool requires backend context (project access).");
+    }
+
+    @Override
+    public McpSchema.CallToolResult execute(Map<String, Object> arguments,
+                                            ghidra.program.model.listing.Program currentProgram,
+                                            GhidrAssistMCPBackend backend) {
+        Project project = getProject();
+        if (project == null) {
+            return textResult("No Ghidra project is open.");
+        }
+
+        String action = (String) arguments.get("action");
+        if (action == null || action.isBlank()) {
+            return textResult("action is required: list or delete.");
+        }
+
+        DomainFolder root = project.getProjectData().getRootFolder();
+        return switch (action.trim().toLowerCase()) {
+            case "list" -> list(root, arguments);
+            case "delete" -> delete(root, arguments, backend);
+            default -> textResult("Invalid action: " + action + ". Use list or delete.");
+        };
+    }
+
+    private Project getProject() {
+        GhidrAssistMCPManager manager = GhidrAssistMCPManager.getInstance();
+        PluginTool pluginTool = manager.getActiveTool();
+        return pluginTool != null ? pluginTool.getProject() : null;
+    }
+
+    private McpSchema.CallToolResult list(DomainFolder root, Map<String, Object> arguments) {
+        String folderPath = stringArg(arguments.get("folder"), "/");
+        boolean recursive = Boolean.TRUE.equals(arguments.get("recursive"));
+
+        DomainFolder folder = resolveFolder(root, folderPath);
+        if (folder == null) {
+            return textResult("Folder not found: " + folderPath);
+        }
+
+        List<String> rows = new ArrayList<>();
+        collect(folder, recursive, rows);
+        rows.sort(String.CASE_INSENSITIVE_ORDER);
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("Project entries under ").append(folder.getPathname()).append("\n\n");
+        for (String row : rows) {
+            sb.append(row).append("\n");
+        }
+        sb.append("\nTotal: ").append(rows.size()).append(" entr").append(rows.size() == 1 ? "y" : "ies");
+        return textResult(sb.toString());
+    }
+
+    private McpSchema.CallToolResult delete(DomainFolder root, Map<String, Object> arguments,
+                                            GhidrAssistMCPBackend backend) {
+        if (!Boolean.TRUE.equals(arguments.get("confirm"))) {
+            return textResult("Refusing to delete. Pass confirm=true to delete a project file or folder.");
+        }
+
+        String path = stringArg(arguments.get("path"), null);
+        if (path == null || path.isBlank()) {
+            return textResult("path is required for action='delete'.");
+        }
+
+        String normalizedPath = normalizePath(path);
+        if ("/".equals(normalizedPath)) {
+            return textResult("Refusing to delete the project root folder.");
+        }
+
+        String targetType = stringArg(arguments.get("target_type"), "auto").toLowerCase();
+        boolean recursive = Boolean.TRUE.equals(arguments.get("recursive"));
+
+        try {
+            if ("file".equals(targetType) || "auto".equals(targetType)) {
+                DomainFile file = resolveFile(root, normalizedPath);
+                if (file != null) {
+                    String deletedPath = file.getPathname();
+                    file.delete();
+                    if (backend != null) {
+                        backend.clearCache();
+                    }
+                    return textResult("Deleted project file: " + deletedPath);
+                }
+                if ("file".equals(targetType)) {
+                    return textResult("Project file not found: " + normalizedPath);
+                }
+            }
+
+            if ("folder".equals(targetType) || "auto".equals(targetType)) {
+                DomainFolder folder = resolveFolder(root, normalizedPath);
+                if (folder == null) {
+                    return textResult("Project folder not found: " + normalizedPath);
+                }
+                int deleted = deleteFolder(folder, recursive);
+                if (backend != null) {
+                    backend.clearCache();
+                }
+                return textResult("Deleted project folder: " + normalizedPath +
+                    " (" + deleted + " entr" + (deleted == 1 ? "y" : "ies") + ")");
+            }
+
+            return textResult("Invalid target_type: " + targetType + ". Use auto, file, or folder.");
+        } catch (Exception e) {
+            Msg.error(this, "Failed to delete project entry: " + normalizedPath, e);
+            return textResult("Failed to delete '" + normalizedPath + "': " +
+                e.getClass().getSimpleName() + ": " + e.getMessage() +
+                "\nIf the file is open in CodeBrowser, close it and try again.");
+        }
+    }
+
+    private int deleteFolder(DomainFolder folder, boolean recursive) throws Exception {
+        if (!recursive && !folder.isEmpty()) {
+            throw new IllegalArgumentException("Folder is not empty. Pass recursive=true to delete children.");
+        }
+
+        int deleted = 0;
+        if (recursive) {
+            for (DomainFile file : folder.getFiles()) {
+                file.delete();
+                deleted++;
+            }
+
+            List<DomainFolder> children = new ArrayList<>(List.of(folder.getFolders()));
+            children.sort(Comparator.comparing(DomainFolder::getPathname).reversed());
+            for (DomainFolder child : children) {
+                deleted += deleteFolder(child, true);
+            }
+        }
+
+        folder.delete();
+        return deleted + 1;
+    }
+
+    private void collect(DomainFolder folder, boolean recursive, List<String> rows) {
+        for (DomainFolder child : folder.getFolders()) {
+            rows.add("[folder] " + child.getPathname());
+            if (recursive) {
+                collect(child, true, rows);
+            }
+        }
+        for (DomainFile file : folder.getFiles()) {
+            rows.add("[file]   " + file.getPathname() + " (" + file.getContentType() + ")");
+        }
+    }
+
+    private DomainFolder resolveFolder(DomainFolder root, String path) {
+        String normalized = normalizePath(path);
+        if ("/".equals(normalized)) {
+            return root;
+        }
+
+        DomainFolder folder = root;
+        for (String part : normalized.substring(1).split("/")) {
+            if (part.isEmpty()) {
+                continue;
+            }
+            folder = folder.getFolder(part);
+            if (folder == null) {
+                return null;
+            }
+        }
+        return folder;
+    }
+
+    private DomainFile resolveFile(DomainFolder root, String path) {
+        String normalized = normalizePath(path);
+        int slash = normalized.lastIndexOf('/');
+        String folderPath = slash <= 0 ? "/" : normalized.substring(0, slash);
+        String fileName = normalized.substring(slash + 1);
+        DomainFolder folder = resolveFolder(root, folderPath);
+        return folder != null ? folder.getFile(fileName) : null;
+    }
+
+    private String normalizePath(String path) {
+        String normalized = path != null ? path.trim().replace('\\', '/') : "/";
+        if (normalized.isEmpty()) {
+            normalized = "/";
+        }
+        if (!normalized.startsWith("/")) {
+            normalized = "/" + normalized;
+        }
+        while (normalized.length() > 1 && normalized.endsWith("/")) {
+            normalized = normalized.substring(0, normalized.length() - 1);
+        }
+        return normalized;
+    }
+
+    private String stringArg(Object value, String defaultValue) {
+        if (value instanceof String text && !text.isBlank()) {
+            return text;
+        }
+        return defaultValue;
+    }
+
+    private McpSchema.CallToolResult textResult(String message) {
+        return McpSchema.CallToolResult.builder()
+            .addTextContent(message)
+            .build();
+    }
+}


### PR DESCRIPTION
- Add Ghidra Auto Analysis MCP tools:
  - `analysis_options` for listing, setting, resetting, and preset management
  - `analyze_program` for current/all-open analysis, range-limited analysis, and option overrides
  - `analysis_control` for status checks and queued analysis cancellation
- Support analyzer sub-options, plugin-provided analyzers, complex option types, and task progress reporting.
- Add project/program lifecycle support:
  - `project_files` for listing/deleting project entries
  - `open_program` analysis prompt suppression and analyze-after-open support
  - `close_program` for closing open CodeBrowser programs before deletion
  - `import_file` analysis prompt suppression when opening imported programs
- Add `scripts` MCP tool for listing, reading, creating, deleting, and running Ghidra scripts.
- Add `clear_existing` support to `disassemble_at` and `create_function` for code/data misclassification recovery.