### PR TITLE
Fix program lookup to match full project path, not just filename

### DIFF
--- a/src/main/java/ghidrassistmcp/GhidrAssistMCPManager.java
+++ b/src/main/java/ghidrassistmcp/GhidrAssistMCPManager.java
@@ -10,6 +10,7 @@ import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import ghidra.app.services.ProgramManager;
+import ghidra.framework.model.DomainFile;
 import ghidra.framework.plugintool.PluginTool;
 import ghidra.framework.preferences.Preferences;
 import ghidra.program.model.listing.Program;
@@ -257,7 +258,15 @@ public class GhidrAssistMCPManager {
 
         List<Program> programs = getAllOpenPrograms();
 
-        // Exact match
+        // Exact project path match (e.g. "/v1/app.exe" disambiguates from "/v2/app.exe")
+        for (Program p : programs) {
+            DomainFile df = p.getDomainFile();
+            if (df != null && df.getPathname().equals(programName)) {
+                return p;
+            }
+        }
+
+        // Exact name match
         for (Program p : programs) {
             if (p.getName().equals(programName)) {
                 return p;

--- a/src/main/java/ghidrassistmcp/GhidrAssistMCPPlugin.java
+++ b/src/main/java/ghidrassistmcp/GhidrAssistMCPPlugin.java
@@ -11,6 +11,7 @@ import ghidra.MiscellaneousPluginPackage;
 import ghidra.app.plugin.PluginCategoryNames;
 import ghidra.app.plugin.ProgramPlugin;
 import ghidra.app.services.ProgramManager;
+import ghidra.framework.model.DomainFile;
 import ghidra.framework.plugintool.*;
 import ghidra.framework.plugintool.util.PluginStatus;
 import ghidra.program.model.address.Address;
@@ -247,21 +248,29 @@ public class GhidrAssistMCPPlugin extends ProgramPlugin {
 
 		List<Program> programs = getAllOpenPrograms();
 
-		// First try exact match
+		// Exact project path match (e.g. "/v1/app.exe" disambiguates from "/v2/app.exe")
+		for (Program p : programs) {
+			DomainFile df = p.getDomainFile();
+			if (df != null && df.getPathname().equals(programName)) {
+				return p;
+			}
+		}
+
+		// Exact name match
 		for (Program p : programs) {
 			if (p.getName().equals(programName)) {
 				return p;
 			}
 		}
 
-		// Try case-insensitive match
+		// Case-insensitive match
 		for (Program p : programs) {
 			if (p.getName().equalsIgnoreCase(programName)) {
 				return p;
 			}
 		}
 
-		// Try partial match (contains)
+		// Partial match
 		for (Program p : programs) {
 			if (p.getName().toLowerCase().contains(programName.toLowerCase())) {
 				return p;

--- a/src/main/java/ghidrassistmcp/tools/OpenProgramTool.java
+++ b/src/main/java/ghidrassistmcp/tools/OpenProgramTool.java
@@ -35,8 +35,8 @@ public class OpenProgramTool implements McpTool {
     public String getDescription() {
         return "Open a program from the Ghidra project in CodeBrowser, or list all " +
                "programs available in the project. " +
-               "Use action 'list' to see all project files, or 'open' to open one by name. " +
-               "Example: {\"action\": \"open\", \"name\": \"bank00.bin\"}";
+               "Use action 'list' to see all project files, or 'open' to open one by name or full path. " +
+               "Example: {\"action\": \"open\", \"name\": \"/banks/bank00.bin\"}";
     }
 
     @Override
@@ -60,7 +60,7 @@ public class OpenProgramTool implements McpTool {
                 ),
                 "name", Map.of(
                     "type", "string",
-                    "description", "Program name to open (required for action 'open'). Supports partial matching."
+                    "description", "Program name or full project path to open (required for action 'open'). Supports partial name matching."
                 ),
                 "folder", Map.of(
                     "type", "string",
@@ -130,7 +130,7 @@ public class OpenProgramTool implements McpTool {
             sb.append("  (").append(df.getContentType()).append(")\n");
         }
         sb.append("\nTotal: ").append(files.size()).append(" file(s)\n");
-        sb.append("\nUse {\"action\": \"open\", \"name\": \"<name>\"} to open one in CodeBrowser.");
+        sb.append("\nUse {\"action\": \"open\", \"name\": \"<pathname>\"} to open one in CodeBrowser.");
 
         return McpSchema.CallToolResult.builder()
             .addTextContent(sb.toString())
@@ -149,7 +149,8 @@ public class OpenProgramTool implements McpTool {
         // Check if already open
         List<Program> openPrograms = backend.getAllOpenPrograms();
         for (Program p : openPrograms) {
-            if (p.getName().equalsIgnoreCase(name)) {
+            String pPath = p.getDomainFile().getPathname();
+            if (p.getName().equalsIgnoreCase(name) || pPath.equalsIgnoreCase(name)) {
                 return textResult("Program '" + p.getName() + "' is already open in CodeBrowser.");
             }
         }
@@ -187,22 +188,36 @@ public class OpenProgramTool implements McpTool {
     }
 
     /**
-     * Find a file by name with exact, case-insensitive, then partial matching.
+     * Find a file by full project path or name, with exact, case-insensitive,
+     * then partial matching. Full pathname (e.g. "/banks/bank00.bin") is tried
+     * before plain name so that callers can paste directly from the 'list' output.
      */
     private DomainFile findFile(List<DomainFile> files, String name) {
-        // Exact match
+        // Exact pathname match (e.g. "/banks/bank00.bin")
+        for (DomainFile df : files) {
+            if (df.getPathname().equals(name)) {
+                return df;
+            }
+        }
+        // Exact name match (e.g. "bank00.bin")
         for (DomainFile df : files) {
             if (df.getName().equals(name)) {
                 return df;
             }
         }
-        // Case-insensitive match
+        // Case-insensitive pathname match
+        for (DomainFile df : files) {
+            if (df.getPathname().equalsIgnoreCase(name)) {
+                return df;
+            }
+        }
+        // Case-insensitive name match
         for (DomainFile df : files) {
             if (df.getName().equalsIgnoreCase(name)) {
                 return df;
             }
         }
-        // Partial match (contains)
+        // Partial name match (contains)
         String lowerName = name.toLowerCase();
         for (DomainFile df : files) {
             if (df.getName().toLowerCase().contains(lowerName)) {


### PR DESCRIPTION
## Problem

When multiple programs share the same filename (e.g. `/v1/app.exe` and `/v2/app.exe`), all lookups matched only on `getName()`, so passing a full project path would silently resolve to whichever hit the name match first.

## Fix

- `getProgramByName()` in `GhidrAssistMCPManager` and `GhidrAssistMCPPlugin` now checks `DomainFile.getPathname()` before falling through to the existing exact/case-insensitive/partial name matching. A full project path now unambiguously selects the right binary.
- `OpenProgramTool.findFile()` does the same — `action: list` already showed full pathnames; now `action: open` with a full path resolves correctly.
- The already-open check in `OpenProgramTool` also compares by pathname.

No other behaviour is changed.

## Test plan

- [ ] Open `/v1/app.exe` and `/v2/app.exe` — passing `program_name: /v1/app.exe` should resolve to the v1 binary, not v2
- [ ] `open_program` with `action: open, name: /v1/app.exe` (full path from list output) — should open the correct one
- [ ] Bare name `app.exe` still works when unambiguous
- [ ] Partial name match still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)