### PR TITLE
Use indexed symbol lookup instead of scanning all functions when resolving function names

### DIFF
--- a/src/main/java/ghidrassistmcp/tools/CommentsTool.java
+++ b/src/main/java/ghidrassistmcp/tools/CommentsTool.java
@@ -330,9 +330,6 @@ public class CommentsTool implements McpTool {
     }
 
     private Function findFunctionByName(Program program, String functionName) {
-        for (Function function : program.getFunctionManager().getFunctions(true)) {
-            if (function.getName().equals(functionName)) return function;
-        }
-        return null;
+        return FunctionLookup.findByName(program, functionName);
     }
 }

--- a/src/main/java/ghidrassistmcp/tools/FunctionLookup.java
+++ b/src/main/java/ghidrassistmcp/tools/FunctionLookup.java
@@ -1,0 +1,100 @@
+/*
+ * Indexed function-by-name lookup shared by tools.
+ */
+package ghidrassistmcp.tools;
+
+import ghidra.program.model.listing.Function;
+import ghidra.program.model.listing.Program;
+import ghidra.program.model.symbol.Namespace;
+import ghidra.program.model.symbol.Symbol;
+import ghidra.program.model.symbol.SymbolIterator;
+import ghidra.program.model.symbol.SymbolType;
+
+/**
+ * Resolves functions by name using the symbol table's name index instead of
+ * iterating every function in the program. A linear scan over
+ * FunctionManager.getFunctions(true) costs one database record read per
+ * function in the program for a single lookup; on large binaries that is
+ * seconds per call. The name index makes the cost proportional to the number
+ * of symbols sharing the exact name (usually one).
+ */
+public final class FunctionLookup {
+
+    private FunctionLookup() {
+    }
+
+    /**
+     * Find a non-external function whose plain name equals {@code name}.
+     * Matches the same set as the linear scan it replaces (iterating
+     * getFunctions(true) and comparing Function.getName()); when several
+     * functions share the name, the lowest entry point wins, mirroring the
+     * address-ordered scan.
+     */
+    public static Function findByName(Program program, String name) {
+        Function best = null;
+        SymbolIterator symbols = program.getSymbolTable().getSymbols(name);
+        while (symbols.hasNext()) {
+            Symbol symbol = symbols.next();
+            if (symbol.getSymbolType() != SymbolType.FUNCTION || symbol.isExternal()) {
+                continue;
+            }
+            if (symbol.getObject() instanceof Function function) {
+                if (best == null || function.getEntryPoint().compareTo(best.getEntryPoint()) < 0) {
+                    best = function;
+                }
+            }
+        }
+        return best;
+    }
+
+    /**
+     * Find a function by plain or C++-qualified name (e.g. "Class::method" or
+     * "Outer::Inner::method"). For qualified names, candidates are found via
+     * the name index on the simple name and filtered by namespace hierarchy.
+     */
+    public static Function findByQualifiedName(Program program, String identifier) {
+        if (identifier.contains("::")) {
+            String[] parts = identifier.split("::");
+            if (parts.length >= 2) {
+                String simpleName = parts[parts.length - 1];
+                String[] namespaceParts = new String[parts.length - 1];
+                System.arraycopy(parts, 0, namespaceParts, 0, parts.length - 1);
+
+                Function best = null;
+                SymbolIterator symbols = program.getSymbolTable().getSymbols(simpleName);
+                while (symbols.hasNext()) {
+                    Symbol symbol = symbols.next();
+                    if (symbol.getSymbolType() != SymbolType.FUNCTION || symbol.isExternal()) {
+                        continue;
+                    }
+                    if (symbol.getObject() instanceof Function function
+                            && matchesNamespaceHierarchy(function, namespaceParts)) {
+                        if (best == null || function.getEntryPoint().compareTo(best.getEntryPoint()) < 0) {
+                            best = function;
+                        }
+                    }
+                }
+                return best;
+            }
+        }
+        return findByName(program, identifier);
+    }
+
+    /**
+     * Walk the function's parent namespaces backwards against the qualified
+     * name's namespace parts (innermost first).
+     */
+    private static boolean matchesNamespaceHierarchy(Function function, String[] namespaceParts) {
+        Namespace ns = function.getParentNamespace();
+        for (int i = namespaceParts.length - 1; i >= 0; i--) {
+            if (ns == null || ns.isGlobal()) {
+                return false;
+            }
+            if (!ns.getName().equals(namespaceParts[i])) {
+                return false;
+            }
+            ns = ns.getParentNamespace();
+        }
+        return true;
+    }
+}

--- a/src/main/java/ghidrassistmcp/tools/GetBasicBlocksTool.java
+++ b/src/main/java/ghidrassistmcp/tools/GetBasicBlocksTool.java
@@ -143,11 +143,6 @@ public class GetBasicBlocksTool implements McpTool {
             // Not an address
         }
 
-        for (Function function : program.getFunctionManager().getFunctions(true)) {
-            if (function.getName().equals(identifier)) {
-                return function;
-            }
-        }
-        return null;
+        return FunctionLookup.findByName(program, identifier);
     }
 }

--- a/src/main/java/ghidrassistmcp/tools/GetCallGraphTool.java
+++ b/src/main/java/ghidrassistmcp/tools/GetCallGraphTool.java
@@ -183,12 +183,6 @@ public class GetCallGraphTool implements McpTool {
         }
 
         // Try as function name
-        for (Function function : program.getFunctionManager().getFunctions(true)) {
-            if (function.getName().equals(identifier)) {
-                return function;
-            }
-        }
-
-        return null;
+        return FunctionLookup.findByName(program, identifier);
     }
 }

--- a/src/main/java/ghidrassistmcp/tools/GetCodeTool.java
+++ b/src/main/java/ghidrassistmcp/tools/GetCodeTool.java
@@ -20,7 +20,6 @@ import ghidra.program.model.pcode.HighFunction;
 import ghidra.program.model.pcode.PcodeBlockBasic;
 import ghidra.program.model.pcode.PcodeOp;
 import ghidra.program.model.pcode.PcodeOpAST;
-import ghidra.program.model.symbol.Namespace;
 import ghidra.util.task.TaskMonitor;
 import ghidrassistmcp.McpTool;
 import io.modelcontextprotocol.spec.McpSchema;
@@ -312,51 +311,7 @@ public class GetCodeTool implements McpTool {
             // Not an address, try as function name
         }
 
-        // Check if this is a qualified name (contains ::)
-        if (identifier.contains("::")) {
-            String[] parts = identifier.split("::");
-            if (parts.length >= 2) {
-                String simpleName = parts[parts.length - 1];
-                String[] namespaceParts = new String[parts.length - 1];
-                System.arraycopy(parts, 0, namespaceParts, 0, parts.length - 1);
-
-                // Search for function with matching name AND namespace
-                for (Function function : program.getFunctionManager().getFunctions(true)) {
-                    if (function.getName().equals(simpleName) &&
-                        matchesNamespaceHierarchy(function, namespaceParts)) {
-                        return function;
-                    }
-                }
-            }
-        }
-
-        // Fall back to simple name search
-        for (Function function : program.getFunctionManager().getFunctions(true)) {
-            if (function.getName().equals(identifier)) {
-                return function;
-            }
-        }
-        return null;
-    }
-
-    /**
-     * Check if a function's namespace hierarchy matches the given qualified path.
-     * For example, if qualifiedPath is ["Outer", "Inner"], checks if function is in Inner,
-     * which is in Outer.
-     */
-    private boolean matchesNamespaceHierarchy(Function function, String[] namespaceParts) {
-        Namespace ns = function.getParentNamespace();
-
-        // Walk backwards through the namespace parts
-        for (int i = namespaceParts.length - 1; i >= 0; i--) {
-            if (ns == null || ns.isGlobal()) {
-                return false; // Ran out of namespaces before matching all parts
-            }
-            if (!ns.getName().equals(namespaceParts[i])) {
-                return false; // Namespace name doesn't match
-            }
-            ns = ns.getParentNamespace();
-        }
-        return true;
+        // Handles C++ qualified names (Class::method) and plain names
+        return FunctionLookup.findByQualifiedName(program, identifier);
     }
 }

--- a/src/main/java/ghidrassistmcp/tools/GetFunctionInfoTool.java
+++ b/src/main/java/ghidrassistmcp/tools/GetFunctionInfoTool.java
@@ -59,24 +59,20 @@ public class GetFunctionInfoTool implements McpTool {
     }
     
     private String getFunctionInfo(Program program, String functionName) {
-        var functionManager = program.getFunctionManager();
-        var functions = functionManager.getFunctions(true);
-        
-        for (var function : functions) {
-            if (function.getName().equals(functionName)) {
-                StringBuilder info = new StringBuilder();
-                info.append("Function Information:\n");
-                info.append("Name: ").append(function.getName(true)).append("\n");
-                info.append("Entry Point: ").append(function.getEntryPoint()).append("\n");
-                info.append("Body: ").append(function.getBody()).append("\n");
-                info.append("Parameter Count: ").append(function.getParameterCount()).append("\n");
-                info.append("Return Type: ").append(function.getReturnType()).append("\n");
-                info.append("Signature: ").append(function.getSignature()).append("\n");
-                
-                return info.toString();
-            }
+        var function = FunctionLookup.findByName(program, functionName);
+        if (function == null) {
+            return "Function not found: " + functionName;
         }
-        
-        return "Function not found: " + functionName;
+
+        StringBuilder info = new StringBuilder();
+        info.append("Function Information:\n");
+        info.append("Name: ").append(function.getName(true)).append("\n");
+        info.append("Entry Point: ").append(function.getEntryPoint()).append("\n");
+        info.append("Body: ").append(function.getBody()).append("\n");
+        info.append("Parameter Count: ").append(function.getParameterCount()).append("\n");
+        info.append("Return Type: ").append(function.getReturnType()).append("\n");
+        info.append("Signature: ").append(function.getSignature()).append("\n");
+
+        return info.toString();
     }
 }

--- a/src/main/java/ghidrassistmcp/tools/GetFunctionSignatureTool.java
+++ b/src/main/java/ghidrassistmcp/tools/GetFunctionSignatureTool.java
@@ -5,7 +5,6 @@ import com.google.gson.JsonObject;
 import ghidra.program.model.address.Address;
 import ghidra.program.model.listing.Function;
 import ghidra.program.model.listing.Program;
-import ghidra.program.model.symbol.Namespace;
 import ghidra.util.task.TaskMonitor;
 import ghidrassistmcp.McpTool;
 import io.modelcontextprotocol.spec.McpSchema;
@@ -103,42 +102,6 @@ public class GetFunctionSignatureTool implements McpTool {
             // Not an address, continue to name lookup.
         }
 
-        if (identifier.contains("::")) {
-            String[] parts = identifier.split("::");
-            if (parts.length >= 2) {
-                String simpleName = parts[parts.length - 1];
-                String[] namespaceParts = new String[parts.length - 1];
-                System.arraycopy(parts, 0, namespaceParts, 0, parts.length - 1);
-
-                for (Function function : program.getFunctionManager().getFunctions(true)) {
-                    if (function.getName().equals(simpleName) &&
-                        matchesNamespaceHierarchy(function, namespaceParts)) {
-                        return function;
-                    }
-                }
-            }
-        }
-
-        for (Function function : program.getFunctionManager().getFunctions(true)) {
-            if (function.getName().equals(identifier)) {
-                return function;
-            }
-        }
-
-        return null;
-    }
-
-    private boolean matchesNamespaceHierarchy(Function function, String[] namespaceParts) {
-        Namespace ns = function.getParentNamespace();
-        for (int i = namespaceParts.length - 1; i >= 0; i--) {
-            if (ns == null || ns.isGlobal()) {
-                return false;
-            }
-            if (!ns.getName().equals(namespaceParts[i])) {
-                return false;
-            }
-            ns = ns.getParentNamespace();
-        }
-        return true;
+        return FunctionLookup.findByQualifiedName(program, identifier);
     }
 }

--- a/src/main/java/ghidrassistmcp/tools/GetFunctionStackLayoutTool.java
+++ b/src/main/java/ghidrassistmcp/tools/GetFunctionStackLayoutTool.java
@@ -81,9 +81,6 @@ public class GetFunctionStackLayoutTool implements McpTool {
                 if (f != null) return f;
             }
         } catch (Exception e) { /* not an address */ }
-        for (Function f : program.getFunctionManager().getFunctions(true)) {
-            if (f.getName().equals(identifier)) return f;
-        }
-        return null;
+        return FunctionLookup.findByName(program, identifier);
     }
 }

--- a/src/main/java/ghidrassistmcp/tools/RenameSymbolTool.java
+++ b/src/main/java/ghidrassistmcp/tools/RenameSymbolTool.java
@@ -587,14 +587,7 @@ final class RenameSymbolCore {
     }
 
     private static Function findFunctionByName(Program program, String functionName) {
-        var functionManager = program.getFunctionManager();
-        var functions = functionManager.getFunctions(true);
-        for (Function function : functions) {
-            if (function.getName().equals(functionName)) {
-                return function;
-            }
-        }
-        return null;
+        return FunctionLookup.findByName(program, functionName);
     }
 
     /**

--- a/src/main/java/ghidrassistmcp/tools/SetCommentTool.java
+++ b/src/main/java/ghidrassistmcp/tools/SetCommentTool.java
@@ -256,14 +256,6 @@ public class SetCommentTool implements McpTool {
      * Find a function by name.
      */
     private Function findFunctionByName(Program program, String functionName) {
-        var functionManager = program.getFunctionManager();
-        var functions = functionManager.getFunctions(true);
-
-        for (Function function : functions) {
-            if (function.getName().equals(functionName)) {
-                return function;
-            }
-        }
-        return null;
+        return FunctionLookup.findByName(program, functionName);
     }
 }

--- a/src/main/java/ghidrassistmcp/tools/SetLocalVariableTypeTool.java
+++ b/src/main/java/ghidrassistmcp/tools/SetLocalVariableTypeTool.java
@@ -175,14 +175,6 @@ public class SetLocalVariableTypeTool implements McpTool {
     }
     
     private Function findFunctionByName(Program program, String functionName) {
-        var functionManager = program.getFunctionManager();
-        var functions = functionManager.getFunctions(true);
-        
-        for (Function function : functions) {
-            if (function.getName().equals(functionName)) {
-                return function;
-            }
-        }
-        return null;
+        return FunctionLookup.findByName(program, functionName);
     }
 }

--- a/src/main/java/ghidrassistmcp/tools/StructTool.java
+++ b/src/main/java/ghidrassistmcp/tools/StructTool.java
@@ -1257,16 +1257,7 @@ public class StructTool implements McpTool {
             // Not an address, try as name
         }
 
-        var functionManager = program.getFunctionManager();
-        var functions = functionManager.getFunctions(true);
-
-        for (Function function : functions) {
-            if (function.getName().equals(identifier)) {
-                return function;
-            }
-        }
-
-        return null;
+        return FunctionLookup.findByName(program, identifier);
     }
 
     private void setupDecompiler(DecompInterface decompiler, Program program) {

--- a/src/main/java/ghidrassistmcp/tools/VariablesTool.java
+++ b/src/main/java/ghidrassistmcp/tools/VariablesTool.java
@@ -359,10 +359,7 @@ public class VariablesTool implements McpTool {
             }
         } catch (Exception e) { /* not an address */ }
 
-        for (Function f : program.getFunctionManager().getFunctions(true)) {
-            if (f.getName().equals(name)) return f;
-        }
-        return null;
+        return FunctionLookup.findByName(program, name);
     }
 
     private static String coalesce(Map<String, Object> arguments, String... keys) {

--- a/src/main/java/ghidrassistmcp/tools/XrefsTool.java
+++ b/src/main/java/ghidrassistmcp/tools/XrefsTool.java
@@ -376,14 +376,6 @@ public class XrefsTool implements McpTool {
      * Find a function by name.
      */
     private Function findFunctionByName(Program program, String functionName) {
-        var functionManager = program.getFunctionManager();
-        var functions = functionManager.getFunctions(true);
-
-        for (Function function : functions) {
-            if (function.getName().equals(functionName)) {
-                return function;
-            }
-        }
-        return null;
+        return FunctionLookup.findByName(program, functionName);
     }
 }


### PR DESCRIPTION
> [!Note] 
> This PR was created with the help of an LLM. All output was reviewed by a human for quality.

Fixes #60 .

Replaces the per-tool linear scans over all functions with a shared `FunctionLookup` utility that uses the symbol table's name index. Exact-name lookups drop from seconds to low milliseconds on large binaries (e.g. `comments` 2843ms → 2.9ms avg); `Class::method` resolution and lowest-address tie-breaking behavior are preserved.
