### PR TITLE
Fix duplicated [Context] banner on async tool results

### DIFF
--- a/src/main/java/ghidrassistmcp/GhidrAssistMCPBackend.java
+++ b/src/main/java/ghidrassistmcp/GhidrAssistMCPBackend.java
@@ -374,7 +374,9 @@ public class GhidrAssistMCPBackend implements McpBackend {
             try {
                 McpSchema.CallToolResult result =
                     tool.execute(arguments, targetProgram, backend, taskContext);
-                result = addActiveContextToResult(result, targetProgram);
+                // Store the raw result. The active-context banner is added once when the
+                // result is retrieved through get_task_status, which goes through the normal
+                // synchronous dispatch path. Adding it here too would duplicate the banner.
                 notifyToolResponse(toolName, result);
                 return result;
             } catch (Exception e) {


### PR DESCRIPTION
Async tool results carried the "[Context] Operating on:" banner twice. The completion lambda in executeToolAsync prepended it before storing the result on the task, and get_task_status - an ordinary non-long-running tool - then returned that stored result through the normal synchronous dispatch path, which prepends the banner again.
Store the raw result instead, so the banner is applied exactly once at the single sync-path site and async matches sync behavior. Affects all async tools and all get_code formats (decompiler, disassembly, pcode). On a small function the duplicate line was ~92 bytes of a 331 byte payload (~28% pure waste).