### PR TITLE
Pin rootProject.name so extension builds are directory-independent

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,5 @@
+// Pin the project name so the built extension is always named GhidrAssistMCP.
+// Without this, Gradle derives project.name from the checkout directory, which
+// build.gradle uses as the extension name - so building from a git worktree or a
+// renamed clone produces a zip that Ghidra installs under the wrong name.
+rootProject.name = 'GhidrAssistMCP'


### PR DESCRIPTION
build.gradle derives the extension name from project.name, which Gradle defaults to the checkout directory name when no settings.gradle exists. Building from a git worktree or renamed clone therefore produced a zip whose root folder, jar, and extension.properties name field all carried the directory name instead of GhidrAssistMCP, so Ghidra installed it under the wrong name and failed to load the plugin.